### PR TITLE
ARKAI-39 alfresco redirector

### DIFF
--- a/vagrant/provisioning/roles/firewall/tasks/main.yml
+++ b/vagrant/provisioning/roles/firewall/tasks/main.yml
@@ -14,6 +14,7 @@
   register: arkcase_ports
   loop:
     - "7070/tcp"   # alfresco
+    - "8443/tcp"   # alfresco alternate
     - "443/tcp"    # httpd
     - "2002/tcp"   # pentaho
     - "8983/tcp"   # solr

--- a/vagrant/provisioning/roles/httpd/tasks/main.yml
+++ b/vagrant/provisioning/roles/httpd/tasks/main.yml
@@ -42,6 +42,14 @@
     dest: /etc/httpd/conf.d/ssl.conf
   register: tls_conf
 
+- name: ArkCase Alfresco redirector
+  become: yes
+  template:
+    backup: yes
+    src: httpd-alfresco-redirect.conf
+    dest: /etc/httpd/conf.d/httpd-alfresco-redirect.conf
+  register: alfresco_redirect_conf
+
 - name: ArkCase index.html
   become: yes
   become_user: apache
@@ -89,7 +97,7 @@
   systemd:
     name: httpd
     state: restarted
-  when: tls_conf is changed or mod_security_conf_updated is changed
+  when: tls_conf is changed or mod_security_conf_updated is changed or alfresco_redirect_conf is changed
 
 - name: see if httpd_can_network_connect is already enabled
   command: /usr/sbin/getsebool httpd_can_network_connect
@@ -104,9 +112,13 @@
 - name: open firewall port
   become: yes
   firewalld:
-    port: "443/tcp"
+    port: "{{ item }}"
     permanent: yes
-    zone: public
     state: enabled
     immediate: yes
+  loop:
+    - "443/tcp"
+    - "8443/tcp"
+
+
 

--- a/vagrant/provisioning/roles/httpd/templates/httpd-alfresco-redirect.conf
+++ b/vagrant/provisioning/roles/httpd/templates/httpd-alfresco-redirect.conf
@@ -1,0 +1,303 @@
+#
+# This is the Apache server configuration file providing SSL support.
+# It contains the configuration directives to instruct the server how to
+# serve pages over an https connection. For detailed information about these 
+# directives see <URL:http://httpd.apache.org/docs/2.4/mod/mod_ssl.html>
+# 
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Required modules: mod_log_config, mod_setenvif, mod_ssl,
+#          socache_shmcb_module (for default value of SSLSessionCache)
+
+#
+# Pseudo Random Number Generator (PRNG):
+# Configure one or more sources to seed the PRNG of the SSL library.
+# The seed data should be of good random quality.
+# WARNING! On some platforms /dev/random blocks if not enough entropy
+# is available. This means you then cannot use the /dev/random device
+# because it would lead to very long connection times (as long as
+# it requires to make more entropy available). But usually those
+# platforms additionally provide a /dev/urandom device which doesn't
+# block. So, if available, use this one instead. Read the mod_ssl User
+# Manual for more details.
+#
+SSLRandomSeed startup file:/dev/urandom 512
+SSLRandomSeed connect file:/dev/urandom 512
+
+
+#
+# When we also provide SSL we have to listen to the 
+# standard HTTP port (see above) and to the HTTPS port
+#
+Listen 0.0.0.0:8443
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#   SSL Cipher Suite:
+#   List the ciphers that the client is permitted to negotiate,
+#   and that httpd will negotiate as the client of a proxied server.
+#   See the OpenSSL documentation for a complete list of ciphers, and
+#   ensure these follow appropriate best practices for this deployment.
+#   httpd 2.2.30, 2.4.13 and later force-disable aNULL, eNULL and EXP ciphers,
+#   while OpenSSL disabled these by default in 0.9.8zf/1.0.0r/1.0.1m/1.0.2a.
+#SSLCipherSuite HIGH:!MD5:!RC4
+#SSLProxyCipherSuite HIGH:!MD5:!RC4
+
+#  By the end of 2016, only TLSv1.2 ciphers should remain in use.
+#  Older ciphers should be disallowed as soon as possible, while the
+#  kRSA ciphers do not offer forward secrecy.  These changes inhibit
+#  older clients (such as IE6 SP2 or IE8 on Windows XP, or other legacy
+#  non-browser tooling) from successfully connecting.  
+#
+#  To restrict mod_ssl to use only TLSv1.2 ciphers, and disable
+#  those protocols which do not support forward secrecy, replace
+#  the SSLCipherSuite and SSLProxyCipherSuite directives above with
+#  the following two directives, as soon as practical.
+SSLCipherSuite HIGH:MEDIUM:!SSLv3:!kRSA
+SSLProxyCipherSuite HIGH:MEDIUM:!SSLv3:!kRSA
+
+#   User agents such as web browsers are not configured for the user's
+#   own preference of either security or performance, therefore this
+#   must be the prerogative of the web server administrator who manages
+#   cpu load versus confidentiality, so enforce the server's cipher order.
+SSLHonorCipherOrder on 
+
+#   SSL Protocol support:
+#   List the protocol versions which clients are allowed to connect with.
+#   Disable SSLv3 by default (cf. RFC 7525 3.1.1).  TLSv1 (1.0) should be
+#   disabled as quickly as practical.  By the end of 2016, only the TLSv1.2
+#   protocol or later should remain in use.
+SSLProtocol TLSv1.2
+#all -SSLv3
+SSLProxyProtocol TLSv1.2
+#all -SSLv3
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is an internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog  builtin
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism 
+#   to use and second the expiring timeout (in seconds).
+#SSLSessionCache         "dbm:{{ root_folder }}/app/acm/httpd/logs/ssl_scache"
+SSLSessionCache        "shmcb:{{ root_folder }}/log/httpd/ssl_scache(512000)"
+SSLSessionCacheTimeout  300
+
+#   OCSP Stapling (requires OpenSSL 0.9.8h or later)
+#
+#   This feature is disabled by default and requires at least
+#   the two directives SSLUseStapling and SSLStaplingCache.
+#   Refer to the documentation on OCSP Stapling in the SSL/TLS
+#   How-To for more information.
+#
+#   Enable stapling for all SSL-enabled servers:
+#SSLUseStapling On
+
+#   Define a relatively small cache for OCSP Stapling using
+#   the same mechanism that is used for the SSL session cache
+#   above.  If stapling is used with more than a few certificates,
+#   the size may need to be increased.  (AH01929 will be logged.)
+#SSLStaplingCache "shmcb:{{ root_folder }}/app/acm/httpd/logs/ssl_stapling(32768)"
+
+#   Seconds before valid OCSP responses are expired from the cache
+#SSLStaplingStandardCacheTimeout 3600
+
+#   Seconds before invalid OCSP responses are expired from the cache
+#SSLStaplingErrorCacheTimeout 600
+
+##
+## SSL Virtual Host Context
+##
+
+<VirtualHost _default_:8443>
+
+#   General setup for the virtual host
+ServerName {{ internal_host }}
+ServerAdmin {{ server_admin }}
+ErrorLog "{{ root_folder }}/log/httpd/alfresco_redirect_error_log"
+TransferLog "{{ root_folder }}/log/httpd/alfresco_redirect_access_log"
+
+#   SSL Engine Switch:
+#   Enable/Disable SSL for this virtual host.
+SSLProxyEngine on
+SSLEngine on
+
+#   Server Certificate:
+#   Point SSLCertificateFile at a PEM encoded certificate.  If
+#   the certificate is encrypted, then you will be prompted for a
+#   pass phrase.  Note that a kill -HUP will prompt again.  Keep
+#   in mind that if you have both an RSA and a DSA certificate you
+#   can configure both in parallel (to also allow the use of DSA
+#   ciphers, etc.)
+#   Some ECC cipher suites (http://www.ietf.org/rfc/rfc4492.txt)
+#   require an ECC certificate which can also be configured in
+#   parallel.
+SSLCertificateFile "{{ ssl_cert }}"
+
+#   Server Private Key:
+#   If the key is not combined with the certificate, use this
+#   directive to point at the key file.  Keep in mind that if
+#   you've both a RSA and a DSA private key you can configure
+#   both in parallel (to also allow the use of DSA ciphers, etc.)
+#   ECC keys, when in use, can also be configured in parallel
+SSLCertificateKeyFile "{{ root_folder }}/data/httpd/httpd.key"
+
+#   Server Certificate Chain:
+#   Point SSLCertificateChainFile at a file containing the
+#   concatenation of PEM encoded CA certificates which form the
+#   certificate chain for the server certificate. Alternatively
+#   the referenced file can be the same as SSLCertificateFile
+#   when the CA certificates are directly appended to the server
+#   certificate for convenience.
+SSLCertificateChainFile "{{ ssl_ca }}"
+
+
+#   Certificate Authority (CA):
+#   Set the CA certificate verification path where to find CA
+#   certificates for client authentication or alternatively one
+#   huge file containing all of them (file must be PEM encoded)
+#   Note: Inside SSLCACertificatePath you need hash symlinks
+#         to point to the certificate files. Use the provided
+#         Makefile to update the hash symlinks after changes.
+#SSLCACertificatePath "{{ root_folder }}/app/acm/httpd/conf/ssl.crt"
+#SSLCACertificateFile "{{ root_folder }}/app/acm/httpd/conf/ssl.crt/ca-bundle.crt"
+
+#   Certificate Revocation Lists (CRL):
+#   Set the CA revocation path where to find CA CRLs for client
+#   authentication or alternatively one huge file containing all
+#   of them (file must be PEM encoded).
+#   The CRL checking mode needs to be configured explicitly
+#   through SSLCARevocationCheck (defaults to "none" otherwise).
+#   Note: Inside SSLCARevocationPath you need hash symlinks
+#         to point to the certificate files. Use the provided
+#         Makefile to update the hash symlinks after changes.
+#SSLCARevocationPath "{{ root_folder }}/app/acm/httpd/conf/ssl.crl"
+#SSLCARevocationFile "{{ root_folder }}/app/acm/httpd/conf/ssl.crl/ca-bundle.crl"
+#SSLCARevocationCheck chain
+
+#   Client Authentication (Type):
+#   Client certificate verification type and depth.  Types are
+#   none, optional, require and optional_no_ca.  Depth is a
+#   number which specifies how deeply to verify the certificate
+#   issuer chain before deciding the certificate is not valid.
+#SSLVerifyClient require
+#SSLVerifyDepth  10
+
+#   TLS-SRP mutual authentication:
+#   Enable TLS-SRP and set the path to the OpenSSL SRP verifier
+#   file (containing login information for SRP user accounts). 
+#   Requires OpenSSL 1.0.1 or newer. See the mod_ssl FAQ for
+#   detailed instructions on creating this file. Example:
+#   "openssl srp -srpvfile {{ root_folder }}/app/acm/httpd/conf/passwd.srpv -add username"
+#SSLSRPVerifierFile "{{ root_folder }}/app/acm/httpd/conf/passwd.srpv"
+
+#   Access Control:
+#   With SSLRequire you can do per-directory access control based
+#   on arbitrary complex boolean expressions containing server
+#   variable checks and other lookup directives.  The syntax is a
+#   mixture between C and Perl.  See the mod_ssl documentation
+#   for more details.
+#<Location />
+#SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+#            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+#            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+#            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+#            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+#           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+#</Location>
+
+#   SSL Engine Options:
+#   Set various options for the SSL engine.
+#   o FakeBasicAuth:
+#     Translate the client X.509 into a Basic Authorisation.  This means that
+#     the standard Auth/DBMAuth methods can be used for access control.  The
+#     user name is the `one line' version of the client's X.509 certificate.
+#     Note that no password is obtained from the user. Every entry in the user
+#     file needs this password: `xxj31ZMTZzkVA'.
+#   o ExportCertData:
+#     This exports two additional environment variables: SSL_CLIENT_CERT and
+#     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+#     server (always existing) and the client (only existing when client
+#     authentication is used). This can be used to import the certificates
+#     into CGI scripts.
+#   o StdEnvVars:
+#     This exports the standard SSL/TLS related `SSL_*' environment variables.
+#     Per default this exportation is switched off for performance reasons,
+#     because the extraction step is an expensive operation and is usually
+#     useless for serving static content. So one usually enables the
+#     exportation for CGI and SSI requests only.
+#   o StrictRequire:
+#     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+#     under a "Satisfy any" situation, i.e. when it applies access is denied
+#     and no other module can change it.
+#   o OptRenegotiate:
+#     This enables optimized SSL connection renegotiation handling when SSL
+#     directives are used in per-directory context. 
+#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+<FilesMatch "\.(cgi|shtml|phtml|php)$">
+    SSLOptions +StdEnvVars
+</FilesMatch>
+#<Directory "{{ root_folder }}/app/acm/httpd/cgi-bin">
+#    SSLOptions +StdEnvVars
+#</Directory>
+
+#   SSL Protocol Adjustments:
+#   The safe and default but still SSL/TLS standard compliant shutdown
+#   approach is that mod_ssl sends the close notify alert but doesn't wait for
+#   the close notify alert from client. When you need a different shutdown
+#   approach you can use one of the following variables:
+#   o ssl-unclean-shutdown:
+#     This forces an unclean shutdown when the connection is closed, i.e. no
+#     SSL close notify alert is sent or allowed to be received.  This violates
+#     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+#     this when you receive I/O errors because of the standard approach where
+#     mod_ssl sends the close notify alert.
+#   o ssl-accurate-shutdown:
+#     This forces an accurate shutdown when the connection is closed, i.e. a
+#     SSL close notify alert is send and mod_ssl waits for the close notify
+#     alert of the client. This is 100% SSL/TLS standard compliant, but in
+#     practice often causes hanging connections with brain-dead browsers. Use
+#     this only for browsers where you know that their SSL implementation
+#     works correctly. 
+#   Notice: Most problems of broken clients are also related to the HTTP
+#   keep-alive facility, so you usually additionally want to disable
+#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+#   "force-response-1.0" for this.
+
+
+# Reverse proxy settings for Arkcase and components
+ProxyPass /alfresco https://{{ internal_host }}:7070/alfresco
+ProxyPassReverse /alfresco https://{{ internal_host }}:7070/alfresco
+
+# special handling for Alfresco Share, due to Share's CSRF filter
+<LocationMatch "/share">
+  ProxyPass https://{{ internal_host }}:7070/share
+  ProxyPassReverse https://{{ internal_host }}:7070/share
+  RequestHeader set Origin "https://{{ internal_host }}:7070"
+  RequestHeader edit Referer "arkcase-ce\.local\/share" "{{ internal_host }}:7070/share" 
+</LocationMatch>
+ProxyPass /share/res https://{{ internal_host }}:7070
+ProxyPassReverse /share/res https://{{ internal_host }}:7070
+
+BrowserMatch "MSIE [2-5]" \
+         nokeepalive ssl-unclean-shutdown \
+         downgrade-1.0 force-response-1.0
+
+#   Per-Server Logging:
+#   The home of a custom SSL log file. Use this when you want a
+#   compact non-error SSL logfile on a virtual host basis.
+CustomLog "{{ root_folder }}/log/httpd/alfresco_redirect_ssl_request_log" \
+          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
+</VirtualHost>                                  


### PR DESCRIPTION
With this change Alfresco is reachable on port 443 (classic httpd proxy), port 7070 (direct port) and port 8443 (this new SSL configuration). 