### PR TITLE
Feature/ldap config fix version check

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -436,7 +436,7 @@
     ldap_user_domain_bean_name: "{{ ldap_user_domain_bean }}"
     ldap_authentication_service_class: "com.armedia.acm.services.users.service.ldap.LdapAuthenticateService"
     portal_prefix: ""
-    ldap_template_name: "{{ 'spring-config-ldap-pre-3.3.3.xml' if arkcase_version is version('3.3.3', '<') else 'spring-config-ldap.xml' }}"  
+    ldap_template_name: "{{ 'spring-config-ldap-pre-3.3.3.xml' if arkcase_version == '' or arkcase_version is version('3.3.3', '<') else 'spring-config-ldap.xml' }}"  
 
 - name: read current config server configuration
   become: yes

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -436,7 +436,7 @@
     ldap_user_domain_bean_name: "{{ ldap_user_domain_bean }}"
     ldap_authentication_service_class: "com.armedia.acm.services.users.service.ldap.LdapAuthenticateService"
     portal_prefix: ""
-    ldap_template_name: "{{ 'spring-config-ldap-pre-3.3.3.xml' if arkcase_version == '' or arkcase_version is version('3.3.3', '<') else 'spring-config-ldap.xml' }}"  
+    ldap_template_name: "spring-config-ldap.xml"
 
 - name: read current config server configuration
   become: yes

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -436,7 +436,7 @@
     ldap_user_domain_bean_name: "{{ ldap_user_domain_bean }}"
     ldap_authentication_service_class: "com.armedia.acm.services.users.service.ldap.LdapAuthenticateService"
     portal_prefix: ""
-    ldap_template_name: "{{ arkcase_version == '' or arkcase_version is version('3.3.3', '>=') | ternary('spring-config-ldap.xml', 'spring-config-ldap-pre-3.3.3.xml') }}"
+    ldap_template_name: "{{ 'spring-config-ldap-pre-3.3.3.xml' if arkcase_version is version('3.3.3', '<') else 'spring-config-ldap.xml' }}"  
 
 - name: read current config server configuration
   become: yes


### PR DESCRIPTION
existing code causes a type error when the arkcase_version is blank (the ternary resolves to a bool instead of a string).  didn't find a way to fix it and got frustrated, so just defaulting to the new template now.