### PR TITLE
RHEL / FIPS fixes

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -26,6 +26,7 @@
       - tar
       - wget
       - sshpass
+      - firewalld
 
 - name: remove python2-passlib since it breaks solr password setting
   become: yes

--- a/vagrant/provisioning/roles/samba/tasks/main.yml
+++ b/vagrant/provisioning/roles/samba/tasks/main.yml
@@ -58,6 +58,7 @@
       - python-ldap
       - python36u
       - python36u-devel
+      - python-firewall
 
 - name: link python3 executable
   become: yes


### PR DESCRIPTION
still need to update Yarn CLI to use sha256 for hashing, versus md5