### PR TITLE
Alfresco 6.1 EE works with MariaDB JDBC 2.2.5

### DIFF
--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -345,8 +345,10 @@ solr_cores:
 
 # NOTE: Alfresco CE 2018-06 does NOT work with
 # higher versions of Maria JDBC; specifically it does NOT
-# work with 2.4.2.  Is known to work with 2.2.6.
-mariadb_jdbc_version: 2.2.6
+# work with 2.4.2.  
+# Also, Alfresco 6.1 EE is certified with 2.2.5... n
+# it doesn't work with 2.2.6.
+mariadb_jdbc_version: 2.2.5
 default_database_password: "@rKc@3S!"
 
 # tomcat_major_version needed to build download URL

--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -346,7 +346,7 @@ solr_cores:
 # NOTE: Alfresco CE 2018-06 does NOT work with
 # higher versions of Maria JDBC; specifically it does NOT
 # work with 2.4.2.  
-# Also, Alfresco 6.1 EE is certified with 2.2.5... n
+# Also, Alfresco 6.1 EE is certified with 2.2.5... 
 # it doesn't work with 2.2.6.
 mariadb_jdbc_version: 2.2.5
 default_database_password: "@rKc@3S!"

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -449,8 +449,10 @@ solr_cores:
 
 # NOTE: Alfresco CE 2018-06 does NOT work with
 # higher versions of Maria JDBC; specifically it does NOT
-# work with 2.4.2.  Is known to work with 2.2.6.
-mariadb_jdbc_version: 2.2.6
+# work with 2.4.2.  
+# Also, Alfresco 6.1 EE is certified with 2.2.5... n
+# it doesn't work with 2.2.6.
+mariadb_jdbc_version: 2.2.5
 default_database_password: "@rM3d1A!"
 
 # tomcat_major_version needed to build download URL

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -450,7 +450,7 @@ solr_cores:
 # NOTE: Alfresco CE 2018-06 does NOT work with
 # higher versions of Maria JDBC; specifically it does NOT
 # work with 2.4.2.  
-# Also, Alfresco 6.1 EE is certified with 2.2.5... n
+# Also, Alfresco 6.1 EE is certified with 2.2.5... 
 # it doesn't work with 2.2.6.
 mariadb_jdbc_version: 2.2.5
 default_database_password: "@rM3d1A!"


### PR DESCRIPTION
Our customer BCGEU found an Alfresco defect in Share's user management.  The defect proves to be triggered by MariaDB JDBC connector 2.2.6... 2.2.5 works OK.