### PR TITLE
update pentaho_ee_licence_year for the new 2020 licenses

### DIFF
--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -329,7 +329,7 @@ jmx_password: P@ssw0rd
 # the installer artifacts from Pentaho's support portal and uploaded
 # them to an SFTP repository.  Also, run the `pentaho_ee` role instead of
 # `pentaho_ce`
-pentaho_ee_license_year: 2019
+pentaho_ee_license_year: 2020
 pentaho_major_version: 8.3
 pentaho_minor_version: 0.0-371
 


### PR DESCRIPTION
The file is updated with a new value for pentaho_ee_license_year to match our new licenses zip file which is on fileshare.armedia.com