### PR TITLE
Use LDAP authenticator until the AD authenticator is fixed for newer ADs

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -500,7 +500,8 @@
     ldap_user_domain_bean_name: "{{ ldap_user_domain_bean }}"
     ldap_authentication_service_class: "com.armedia.acm.services.users.service.ldap.LdapAuthenticateService"
     portal_prefix: ""
-    ldap_template_name: "spring-config-ldap.xml"
+    # until our Active Directory authenticator works with AD 2016 we will stick with our old LDAP authenticator
+    ldap_template_name: "spring-config-ldap-pre-3.3.3.xml"
 
 - name: read current config server configuration
   become: yes


### PR DESCRIPTION
On Active Directory newer than 2007 or so, our AD authenticator doesn't work (https://project.armedia.com/jira/browse/AFDP-8708)