### PR TITLE
Arkcase upgrade playbook with tags

### DIFF
--- a/vagrant/provisioning/arkcase-app-upgrade.yml
+++ b/vagrant/provisioning/arkcase-app-upgrade.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  roles:
+    - role: common
+      tags: [core]
+    - role: arkcase-pre-upgrade
+      tags: [core]
+    - role: arkcase-prerequisites
+      tags: [core]
+    - role: arkcase-app
+      tags: [core]
+    - role: foia
+      tags: [foia]
+    - role: arkcase-post-upgrade
+      tags: [core]
+    - role: snowbound-app
+      tags: [core]


### PR DESCRIPTION
To start arkcase upgrade from GitlabCI using one template for different servers (each inventory has it's own facts) we can execute this command:

> curl -H "Content-Type: application/json" -X POST -s -u gitlabci:XXXX -d '{ "inventory": 44, "job_tags": "core,foia", "extra_vars": "{\"arkcase_version\": \"3.3.5-RC1\", \"arkcase_configuration_version\":\"3.3.5-RC1\", \"arkcase_config_server_version\":\"3.3.5-RC1\", \"snowbound_arkcase_version\":\"3.3.5-RC1\"}"}' -k https://tower.armedia.com/api/v2/job_templates/129/launch/

Unfortunately, the inventory must be an ID (44) also the template to run is an ID (129). 
