### PR TITLE
update the main.yml

### DIFF
--- a/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
@@ -6,6 +6,17 @@
     - "acm-config-server-repo/arkcase-runtime.yaml"
     - "acmSequenceConfiguration.json"
 
+- name: restore branding files 
+  become: yes
+  become_user: arkcase
+  command: cp {{ config_backup_folder_path }}/acm/acm-config-server-repo/branding/{{ item }} {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/branding/{{ item }}
+  loop:
+    - "email-logo-runtime.png"
+    - "header-logo-runtime.png"
+    - "login-logo-runtime.png"
+    - "custom-runtime.css"
+  ignore_errors: true
+  
 - name: start config server
   become: yes
   systemd:


### PR DESCRIPTION
Change to the ansible role in which we copy the -runtime files from the branding folder from the pre-update .arkcase configuration folder to the new version of .arkcase thus retaining the logos and brandings