### PR TITLE
Require admin access for Solr web application

### DIFF
--- a/vagrant/provisioning/roles/httpd/tasks/main.yml
+++ b/vagrant/provisioning/roles/httpd/tasks/main.yml
@@ -34,6 +34,13 @@
     group: apache
     mode: 0600
 
+- name: Allow only LDAP authenticated users to have access to Solr
+  become: yes
+  template:
+    backup: yes
+    src: ldap-auth-restricted-linuxadmins-helper.script2
+    dest: /etc/httpd/conf.d/    
+    
 - name: ArkCase TLS configuration
   become: yes
   template:

--- a/vagrant/provisioning/roles/httpd/templates/httpd-ssl.conf
+++ b/vagrant/provisioning/roles/httpd/templates/httpd-ssl.conf
@@ -288,6 +288,9 @@ SSLCertificateChainFile "{{ ssl_ca }}"
 # Reverse proxy settings for Arkcase and components
 ProxyPass /solr https://{{ solr_host }}:8983/solr
 ProxyPassReverse /solr https://{{ solr_host }}:8983/solr
+<Location /solr>
+  Include conf.d/ldap-auth-restricted-linuxadmins-helper.script2
+</Location>
 
 ProxyPass /alfresco https://{{ alfresco_host }}:7070/alfresco
 ProxyPassReverse /alfresco https://{{ alfresco_host }}:7070/alfresco

--- a/vagrant/provisioning/roles/httpd/templates/ldap-auth-restricted-linuxadmins-helper.script2
+++ b/vagrant/provisioning/roles/httpd/templates/ldap-auth-restricted-linuxadmins-helper.script2
@@ -1,0 +1,14 @@
+AuthType Basic
+AuthName "Authentication Required"
+AuthBasicProvider ldap
+RewriteEngine On
+#LDAPReferrals Off
+# Perform LDAP lookup for user to check group membership
+AuthLDAPUrl "{{ ldap_url }}/{{ ldap_base }}?{{ ldap_remote_user_attribute | default('sAMAccountName') }}?sub?(objectClass=*)"
+AuthLDAPBindDN "{{ ldap_base }}"
+AuthLDAPBindPassword "{{ ldap_bind_password }}"
+AuthzLDAPAuthoritative off
+#AuthLDAPInitialBindAsUser off
+AuthLDAPRemoteUserAttribute "{{ ldap_remote_user_attribute | default('sAMAccountName') }}"
+Require ldap-filter &(objectClass=person)(objectClass=user)(memberOf=CN="{{ ldap_CN | default ('linuxadmins') }}","{{ ldap_base }}")((userAccountControl:1.2.840.113556.1.4.803:=2))
+require valid-user

--- a/vagrant/provisioning/roles/httpd/templates/ldap-auth-restricted-linuxadmins-helper.script2
+++ b/vagrant/provisioning/roles/httpd/templates/ldap-auth-restricted-linuxadmins-helper.script2
@@ -10,5 +10,5 @@ AuthLDAPBindPassword "{{ ldap_bind_password }}"
 AuthzLDAPAuthoritative off
 #AuthLDAPInitialBindAsUser off
 AuthLDAPRemoteUserAttribute "{{ ldap_remote_user_attribute | default('sAMAccountName') }}"
-Require ldap-filter &(objectClass=person)(objectClass=user)(memberOf=CN="{{ ldap_CN | default ('linuxadmins') }}","{{ ldap_base }}")((userAccountControl:1.2.840.113556.1.4.803:=2))
+Require ldap-filter &(objectClass=person)(objectClass=user)(memberOf=CN="{{ solr_web_console_access_group_name | default ('linuxadmins') }}","{{ ldap_base }}")
 require valid-user


### PR DESCRIPTION
Additions to the 'httpd role' are added in order to achieve only LDAP authenticated users to have access to Solr web app.