### PR TITLE
Added follow_redirects for the uri module of alfresco role since it was failing

### DIFF
--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -474,6 +474,7 @@
   uri:
     url: https://localhost:7070/share/page/
     validate_certs: false
+    follow_redirects: all
   retries: 10
   delay: 10
 


### PR DESCRIPTION
We need to add "follow_redirects: all" since the link is redirecting us and causes the play to fail