### PR TITLE
Changed Samba repository as the old one was decomissioned

### DIFF
--- a/vagrant/provisioning/roles/samba/tasks/main.yml
+++ b/vagrant/provisioning/roles/samba/tasks/main.yml
@@ -37,7 +37,7 @@
   become: yes
   yum:
     state: installed
-    name: https://centos7.iuscommunity.org/ius-release.rpm
+    name: https://repo.ius.io/ius-release-el7.rpm
 
 - name: Samba and LDAP required packages
   become: yes


### PR DESCRIPTION
The old samba repository is decomissioned centos7.iuscommunity.org/ius-release.rpm