### PR TITLE
Added the role alfresco-site to create the sites in Alfresco

### DIFF
--- a/vagrant/provisioning/arkcase-ce-external-ldap-foia-pki.yml
+++ b/vagrant/provisioning/arkcase-ce-external-ldap-foia-pki.yml
@@ -21,6 +21,8 @@
       tags: [core, alfresco, alfresco-ce]
     - role: alfresco
       tags: [core, alfresco]
+    - role: alfresco-site
+      tags: [core, alfresco, alfresco-site]
     - role: solr
       tags: [core, solr]
     - role: pentaho-setup


### PR DESCRIPTION
We have somehow omitted this role in the installer and by doing this we do not create any site inside Alfresco thus creating a problem where ArkCase cannot create task or person etc.