### PR TITLE
Zookeeper systemd unit file and new logrotation policy for Kafka logs

### DIFF
--- a/vagrant/provisioning/roles/confluent-platform-install/tasks/main.yml
+++ b/vagrant/provisioning/roles/confluent-platform-install/tasks/main.yml
@@ -63,6 +63,22 @@
     force: yes
     backup: yes
 
+- name: Change logrotation policy for Kafka app logs
+  become: yes
+  template:
+    src: log4j.properties
+    dest: /etc/kafka/
+    force: yes
+    backup: yes
+
+- name: Change logrotation policy for Connect logs
+  become: yes
+  template:
+    src: connect-log4j.properties
+    dest: /etc/kafka
+    force: yes
+    backup: yes
+
 - name: Kafka systemd unit file
   become: yes
   template:
@@ -71,10 +87,18 @@
     backup: yes
   register: systemd_kafka_updated
 
+- name: Zookeeper systemd unit file
+  become: yes
+  template:
+    src: confluent-zookeeper.service
+    dest: /etc/systemd/system/confluent-zookeeper.service
+    backup: yes
+  register: systemd_zookeeper_updated
+
 - name: Reload daemon files if needed
   become: yes
   command: systemctl daemon-reload
-  when: systemd_kafka_updated is changed
+  when: systemd_kafka_updated is changed or systemd_zookeeper_updated is changed
 
 - name: Enable zookeeper to start on boot
   become: yes

--- a/vagrant/provisioning/roles/confluent-platform-install/templates/confluent-zookeeper.service
+++ b/vagrant/provisioning/roles/confluent-platform-install/templates/confluent-zookeeper.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apache Kafka - ZooKeeper
+Documentation=http://docs.confluent.io/
+After=network.target
+
+[Service]
+Type=simple
+User=cp-kafka
+Group=confluent
+Environment="LOG_DIR={{ root_folder }}/log/kafka"
+ExecStart=/usr/bin/zookeeper-server-start /etc/kafka/zookeeper.properties
+TimeoutStopSec=180
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/provisioning/roles/confluent-platform-install/templates/connect-log4j.properties
+++ b/vagrant/provisioning/roles/confluent-platform-install/templates/connect-log4j.properties
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.rootLogger=INFO, connectAppender
+
+# Send the logs to the console.
+#
+
+# Send the logs to a file, rolling the file at midnight local time. For example, the `File` option specifies the
+# location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
+# and copied in the same directory but with a filename that ends in the `DatePattern` option.
+#
+log4j.appender.connectAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
+log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.connectAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.connectAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
+# in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
+#
+connect.log.pattern=[%d] %p %m (%c:%L)%n
+#connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+
+log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
+log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
+
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.I0Itec.zkclient=ERROR
+log4j.logger.org.reflections=ERROR

--- a/vagrant/provisioning/roles/confluent-platform-install/templates/log4j.properties
+++ b/vagrant/provisioning/roles/confluent-platform-install/templates/log4j.properties
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unspecified loggers and loggers with additivity=true output to server.log and stdout
+# Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
+log4j.rootLogger=INFO, kafkaAppender
+
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+log4j.appender.stateChangeAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
+log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stateChangeAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.stateChangeAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
+log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.requestAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.requestAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
+log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.cleanerAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.cleanerAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
+log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.controllerAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.controllerAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
+log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.authorizerAppender.MaxFileSize={{ kafka_log4j_max_file_size | default(10MB) }}
+log4j.appender.authorizerAppender.MaxBackupIndex={{ kafka_log4j_max_number | default(5) }}
+
+# Change the line below to adjust ZK client logging
+log4j.logger.org.I0Itec.zkclient.ZkClient=INFO
+log4j.logger.org.apache.zookeeper=INFO
+
+# Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
+log4j.logger.kafka=INFO
+log4j.logger.org.apache.kafka=INFO
+
+# Change to DEBUG or TRACE to enable request logging
+log4j.logger.kafka.request.logger=WARN, requestAppender
+log4j.additivity.kafka.request.logger=false
+
+# Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
+# related to the handling of requests
+#log4j.logger.kafka.network.Processor=TRACE, requestAppender
+#log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
+#log4j.additivity.kafka.server.KafkaApis=false
+log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
+log4j.additivity.kafka.network.RequestChannel$=false
+
+log4j.logger.kafka.controller=TRACE, controllerAppender
+log4j.additivity.kafka.controller=false
+
+log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
+log4j.additivity.kafka.log.LogCleaner=false
+
+log4j.logger.state.change.logger=TRACE, stateChangeAppender
+log4j.additivity.state.change.logger=false
+
+# Access denials are logged at INFO level, change to DEBUG to also log allowed accesses
+log4j.logger.kafka.authorizer.logger=INFO, authorizerAppender
+log4j.additivity.kafka.authorizer.logger=false


### PR DESCRIPTION
- In the zookeeper systemd unit file, we should include LOG_DIR system variable in order zookeeper to know where to store it logs.
- New policy for logrotation is implemented for Kafka application logs. 