### PR TITLE
Drools rules files moved to Config Server

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/update_rules_spreadsheets.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/update_rules_spreadsheets.yml
@@ -9,6 +9,10 @@
   register: rule_update
   changed_when: "'replacing' in rule_update.stdout"
 
+- name: server extension to drools files
+  set_fact:
+    server_extension: "{{ '-server' if (arkcase_version == "" or arkcase_version is version('2020.13', '>=')) else '' }}'
+
 - name: backup original file and replace with updatd file, if necessary
   become: yes
   become_user: arkcase
@@ -16,4 +20,4 @@
   when: rule_update is changed 
   loop:
     - mv {{ s.base_path_no_xlsx }}.xlsx {{ s.base_path_no_xlsx }}-backup.xlsx
-    - mv {{ s.base_path_no_xlsx }}-updated.xlsx {{ s.base_path_no_xlsx }}.xlsx
+    - mv {{ s.base_path_no_xlsx }}-updated.xlsx {{ s.base_path_no_xlsx }}{{ server_extension }}.xlsx


### PR DESCRIPTION
The facts will need to change the rules files path like:

```
rules_spreadsheet_updates:
  base_path_no_xlsx: /home/arkcase/.arkcase/acm/rules/drools-assignment-rules-foia
```
to:
```
rules_spreadsheet_updates:
  base_path_no_xlsx: /home/arkcase/.arkcase/acm/acm-config-server-repo/rules/drools-assignment-rules-foia
```