### PR TITLE
Drools rules xlsx files fixed output filenames

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/update_rules_spreadsheets.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/update_rules_spreadsheets.yml
@@ -12,6 +12,10 @@
 - name: server extension to drools files
   set_fact:
     server_extension: "{{ '-server' if (arkcase_version == '' or arkcase_version is version('2020.13', '>=')) else '' }}"
+    
+- name: server file name
+  set_fact:
+    output_file_name: "{{ s.output_path if (s.output_path is defined) else s.base_path_no_xlsx ~ server_extension ~ '.xlsx' }}"
 
 - name: backup original file and replace with updatd file, if necessary
   become: yes
@@ -20,4 +24,4 @@
   when: rule_update is changed 
   loop:
     - mv {{ s.base_path_no_xlsx }}.xlsx {{ s.base_path_no_xlsx }}-backup.xlsx
-    - mv {{ s.base_path_no_xlsx }}-updated.xlsx {{ s.base_path_no_xlsx }}{{ server_extension }}.xlsx
+    - mv {{ s.base_path_no_xlsx }}-updated.xlsx {{ output_file_name }}


### PR DESCRIPTION
Support for a fixed output filename.
- base_path_no_xlsx: /home/arkcase/.arkcase/acm/acm-config-server-repo/rules/drools-task-rules-foia
  **output_path: /home/arkcase/.arkcase/acm/acm-config-server-repo/rules/drools-assignment-rules-server.xlsx**
  replacements: '"setAssignee, ''owen.officer@arkcase.org'''
