### PR TITLE
Removed admin from external.authentication.defaultAdministratorUserNames

### DIFF
--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -313,7 +313,7 @@
       alfresco-pdf-renderer.exe=${alfresco-pdf-renderer.root}/alfresco-pdf-renderer
       external.authentication.proxyUserName=
       external.authentication.enabled=true
-      external.authentication.defaultAdministratorUserNames=admin
+      external.authentication.defaultAdministratorUserNames=
       external.authentication.proxyHeader=X-Alfresco-Remote-User
       synchronization.synchronizeChangesOnly=false
       ldap.authentication.active=true


### PR DESCRIPTION
As per DSO-48 we noticed that the external authentication wasn't working. 
The current fix is to remove the admin from external.authentication.defaultAdministratorUserNames as this will fix the issue.