### PR TITLE
Changed the copy module with the command module

### DIFF
--- a/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
@@ -176,31 +176,44 @@
     - src: "arkcase-preauth.xml"
       dest: "{{ root_folder }}/app/pentaho/pentaho-server/pentaho-solutions/system/"
 
+#- name: Update Pentaho to support report designer within ArkCase iframe
+#  copy:
+#    src: "{{ item.src }}"
+#    dest: "{{ item.dest }}"
+#    mode: preserve
+#    remote_src: true
+#  loop:
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties/"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/content"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/css"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/js"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/images/"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/lib"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/css/browser.css"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/css/"
+#    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/"
+#      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+
 - name: Update Pentaho to support report designer within ArkCase iframe
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: preserve
-    remote_src: true
-  loop:
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties/"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/content"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/css"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/js"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/images/"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/lib"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/css/browser.css"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/css/"
-    - src: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/"
-      dest: "{{ root_folder }}/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle"
+  command: "{{ item }}"
+  with_items:
+    - cp -p /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties/* /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/content /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/css /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/js /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -p /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/images/* /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/images/
+    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/lib /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -p /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/css/browser.css /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/css/
+    - cp -pf /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/* /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
 
 - name: Replace modernizr
   lineinfile:


### PR DESCRIPTION
For the DSO-42 task we have created a DSO-29 task that was supposed update pentaho to support report designer within ArkCase iFrame. The task was failing since the ansible version that we use on our AWX Tower does not support recursive copying of files with remote_src: true. For this purpose I have deliberately commented the copy module and added a new command module so once we have our AWX Tower version updated we can continue using the idempotent copy module instead of command module.