### PR TITLE
Port 8404 for haproxy statistics

### DIFF
--- a/vagrant/provisioning/roles/haproxy/tasks/main.yml
+++ b/vagrant/provisioning/roles/haproxy/tasks/main.yml
@@ -8,6 +8,7 @@
   loop:
     - "80/tcp"
     - "443/tcp"
+    - "8404/tcp"
 
 - name: install epel-release 
   become: yes


### PR DESCRIPTION
The port 8404 should be open on the firewall