### PR TITLE
Changes in the Command module of pentaho-configuration to use variables

### DIFF
--- a/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
@@ -205,15 +205,15 @@
 - name: Update Pentaho to support report designer within ArkCase iframe
   command: "{{ item }}"
   with_items:
-    - cp -p /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties/* /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
-    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
-    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/content /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
-    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/css /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
-    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/js /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
-    - cp -p /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/images/* /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/images/
-    - cp -rp /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/lib /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
-    - cp -p /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/css/browser.css /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/css/
-    - cp -pf /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/* /opt/app/acm/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -p "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties/* "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/properties "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/content "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/css "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -rp "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/js "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -p "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/home/images/* "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/images/
+    - cp -rp "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/lib "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
+    - cp -p "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/css/browser.css "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/css/
+    - cp -pf "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/browser/* "{{ root_folder }}"/app/pentaho/pentaho-server/tomcat/webapps/pentaho/mantle/
 
 - name: Replace modernizr
   lineinfile:


### PR DESCRIPTION
I have forgotten to add the variable in the path for the cp command inside the command module so this adds the root_folder variable