### PR TITLE
Changed the path and name of zip

### DIFF
--- a/vagrant/provisioning/roles/foia-analytical-reports/tasks/main.yml
+++ b/vagrant/provisioning/roles/foia-analytical-reports/tasks/main.yml
@@ -213,5 +213,5 @@
 #########################################################
 
 - name: import reports from the zip file archive
-  command: "{{ root_folder }}/app/pentaho/pentaho-server/import-export.sh --import --url=https://{{ internal_host }}:2002/pentaho --username={{ ldap_user_prefix }}arkcase-admin --password='{{ arkcase_admin_password }}' --charset=UTF-8 --path=/public/foia --file-path='{{ root_folder }}/install/pentaho/foia-reports-dw-{{ foia_analytical_reports_version }}/reports/Marjan.zip' --permission=true --overwrite=true --retainOwnership=true"
+  command: "{{ root_folder }}/app/pentaho/pentaho-server/import-export.sh --import --url=https://{{ internal_host }}:2002/pentaho --username={{ ldap_user_prefix }}arkcase-admin --password='{{ arkcase_admin_password }}' --charset=UTF-8 --path=/public --file-path='{{ root_folder }}/install/pentaho/foia-reports-dw-{{ foia_analytical_reports_version }}/reports/foia.zip' --permission=true --overwrite=true --retainOwnership=true"
 


### PR DESCRIPTION
Changed the path of the deployment of the reports in pentaho to /public as the new zip file from Marjan will be zipped under foia directory.
Alsto the name of the zip file is changed from Marjan.zip to foia.zip. Although I belive that we should make this as a fact if we are to have different versions of reports, if not we can leave it as it is.

Also, we will merge this after Marjan has made the changes on his part.