### PR TITLE
Changed the facts file for the local developers VM's to enable the el…

### DIFF
--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -500,5 +500,5 @@ confluent_scala_version: 2.12
 
 zipkin_version: 2.21.4
 # Enable these for Arkcase.NEXT development
-enable_elasticsearch: "no"
-enable_kafka: "no"
+enable_elasticsearch: "yes"
+enable_kafka: "yes"


### PR DESCRIPTION
…asticsearch and confluent servies


By default the confluent services were not started on the developers VM's.
By doing this I have enabled them and they should have no problems anymore.

Furthermore this might cause issues with the developers who won't be working on ADK since their current laptops might not support all the services running due to limited RAM resources. 

If someone can suggest another approach we can make the changes accordingly.
