### PR TITLE
Copy the arkcase-portal-server.yaml from backup

### DIFF
--- a/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
@@ -31,3 +31,13 @@
     - "custom-runtime.css"
   when: latest_config_backup_folder is defined
   ignore_errors: true
+
+ - name: Restore arkcase portal configuration
+   become: yes
+   become_user: arkcase
+   command: cp -f {{ latest_config_backup_folder.path }}/acm/acm-config-server-repo/{{ item }} {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/{{ item }}
+   loop:
+     - "arkcase-portal-server.yaml"
+     - "arkcase-portal-server.yaml"
+   when: foia_portal_context is defined
+   ignore_errors: true

--- a/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
@@ -38,6 +38,5 @@
    command: cp -f {{ latest_config_backup_folder.path }}/acm/acm-config-server-repo/{{ item }} {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/{{ item }}
    loop:
      - "arkcase-portal-server.yaml"
-     - "arkcase-portal-server.yaml"
    when: foia_portal_context is defined
    ignore_errors: true


### PR DESCRIPTION
Here I am taking the same approach as restoring the branding files. I get the latest .arkcase backup and get the arkcase-portal-server.yaml from that location and copy it to the new .arkcase configuration folder, thus retaining the old foia portal configuration. 
Also this task will only execute if the installation is foia based and a flag "ignore_errors: true" is set in case this is a first time installation in which case we won't have a previous backup from which the ansible play would take the file.