### PR TITLE
Removed control-center context from httpd role and put it in microsevices role

### DIFF
--- a/vagrant/provisioning/roles/httpd/tasks/main.yml
+++ b/vagrant/provisioning/roles/httpd/tasks/main.yml
@@ -69,29 +69,6 @@
       </Directory>
   when: foia_portal_context is defined
 
-- name: Control-center context, if needed
-  become: yes
-  blockinfile:
-    backup: yes
-    marker: "# {mark} ANSIBLE MANAGED BLOCK CONTROL-CENTER CONTEXT"
-    insertbefore: "</VirtualHost>"
-    path: "/etc/httpd/conf.d/ssl.conf"
-    block: |
-      ProxyPass /control-center http://{{ internal_host }}:9021
-      ProxyPassReverse /control-center http://{{ internal_host }}:9021
-      <Location "/control-center">
-        AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
-        AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE application/javascript
-        SubstituteMaxLineLength 10M
-        Substitute "s|/dist/|/control-center/dist/|i"
-        Substitute "s|/2.0/|/control-center/2.0/|i"
-        Substitute "s|/3.0/|/control-center/3.0/|i"
-        Substitute "s|/api/|/control-center/api/|i"
-        Substitute "s|{{ internal_host }}/clusters/|{{ internal_host }}/control-center/clusters/|i"
-      </Location>
-  when: enable_kafka is defined and enable_kafka == "yes" 
-  register: control_center_httpd
-
 - name: ArkCase index.html
   become: yes
   become_user: apache
@@ -139,7 +116,7 @@
   systemd:
     name: httpd
     state: restarted
-  when: tls_conf is changed or mod_security_conf_updated is changed or control_center_httpd is changed
+  when: tls_conf is changed or mod_security_conf_updated is changed
 
 - name: Check whether I am inside a Docker container
   stat:

--- a/vagrant/provisioning/roles/microservices/tasks/main.yaml
+++ b/vagrant/provisioning/roles/microservices/tasks/main.yaml
@@ -22,12 +22,37 @@
     state: latest
     name:
       - httpd
+  register: httpd_upgrade
+
+- name: Populate control-center context, if needed
+  become: yes
+  blockinfile:
+    backup: yes
+    marker: "# {mark} ANSIBLE MANAGED BLOCK CONTROL-CENTER CONTEXT"
+    insertbefore: "</VirtualHost>"
+    path: "/etc/httpd/conf.d/ssl.conf"
+    block: |
+      ProxyPass /control-center http://{{ internal_host }}:9021
+      ProxyPassReverse /control-center http://{{ internal_host }}:9021
+      <Location "/control-center">
+        AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
+        AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE application/javascript
+        SubstituteMaxLineLength 10M
+        Substitute "s|/dist/|/control-center/dist/|i"
+        Substitute "s|/2.0/|/control-center/2.0/|i"
+        Substitute "s|/3.0/|/control-center/3.0/|i"
+        Substitute "s|/api/|/control-center/api/|i"
+        Substitute "s|{{ internal_host }}/clusters/|{{ internal_host }}/control-center/clusters/|i"
+      </Location>
+  when: enable_kafka is defined and enable_kafka == "yes"
+  register: control_center_httpd 
 
 - name: name restart HTTPD
   become: yes
   systemd:
     name: "httpd"
     state: restarted
+  when: httpd_upgrade is changed or control_center_httpd is changed
 
 - name: Create zipkin user
   become: yes


### PR DESCRIPTION
Installer by default from the CentOS 7 default repo install HTTPD version 2.4.6
In the microservices role, there is a block for updating httpd to the latest version from specific repo since for the SubstituteMaxLineLength we need at least 2.4.11 version