### PR TITLE
Changed kafka server.properties to allow connection from outside

### DIFF
--- a/vagrant/provisioning/roles/confluent-platform-install/templates/server.properties
+++ b/vagrant/provisioning/roles/confluent-platform-install/templates/server.properties
@@ -33,7 +33,7 @@ listeners=PLAINTEXT://:{{ kafka_port | default(9092) }}
 # Hostname and port the broker will advertise to producers and consumers. If not set, 
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value
 # returned from java.net.InetAddress.getCanonicalHostName().
-#advertised.listeners=PLAINTEXT://your.host.name:9092
+advertised.listeners=PLAINTEXT://{{ internal_host }}:{{ kafka_port | default(9092) }}
 
 # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
 #listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL


### PR DESCRIPTION
This will help the developers to connect their config server with their Kafka using the default configurations.