### PR TITLE
Update the "Wait for alfresco startup to finish"

### DIFF
--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -503,7 +503,7 @@
 - name: wait for Alfresco startup to finish
   wait_for:
     port: 7070
-    delay: 3
+    delay: 5
     timeout: 180
 
 - name: Wait for URI


### PR DESCRIPTION
Changed the delay parameter from 3 to 5 since this is causing the Ansible installer to fail probably because Alfresco i still starting