### PR TITLE
Added restart=always in confluent-schema-registry systemd unit file

### DIFF
--- a/vagrant/provisioning/roles/confluent-platform-install/templates/confluent-schema-registry.service
+++ b/vagrant/provisioning/roles/confluent-platform-install/templates/confluent-schema-registry.service
@@ -10,7 +10,7 @@ Group=confluent
 Environment="LOG_DIR={{ root_folder }}/log/schema-registry"
 ExecStart=/usr/bin/schema-registry-start {{ root_folder }}/app/schema-registry/schema-registry.properties
 TimeoutStopSec=180
-Restart=no
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Restart = always has been added into schema-registry systemd unit file since by default schema registry doesn't start in case when the instance goes in reboot