### PR TITLE
Restore all runtime files from all subfolders of acm-config-server-repo

### DIFF
--- a/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
@@ -20,27 +20,9 @@
     - "acmSequenceConfiguration.json"
   when: latest_config_backup_folder is defined
 
-- name: restore branding files 
-  become: yes
-  become_user: arkcase
-  command: cp {{ latest_config_backup_folder.path }}/acm/acm-config-server-repo/branding/{{ item }} {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/branding/{{ item }}
-  loop:
-    - "email-logo-runtime.png"
-    - "header-logo-runtime.png"
-    - "login-logo-runtime.png"
-    - "custom-runtime.css"
-  when: latest_config_backup_folder is defined
-  ignore_errors: true
-
 - name: Restore runtime files from previous backup
   become: yes
   become_user: arkcase
-  command: cp -rf {{ latest_config_backup_folder.path }}/acm/acm-config-server-repo/{{ item }}/*runtime* {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/{{ item }}
-  loop:
-    - "branding"
-    - "labels"
-    - "ldap"
-    - "lookups"
-    - "rules"
-    - "spring"
+  command: rsync -avm --include='*runtime*' -f 'hide,! */' {{ latest_config_backup_folder.path }}/acm/acm-config-server-repo/ {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/
+  when: latest_config_backup_folder is defined
   ignore_errors: true

--- a/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-post-upgrade/tasks/main.yml
@@ -31,3 +31,16 @@
     - "custom-runtime.css"
   when: latest_config_backup_folder is defined
   ignore_errors: true
+
+- name: Restore runtime files from previous backup
+  become: yes
+  become_user: arkcase
+  command: cp -rf {{ latest_config_backup_folder.path }}/acm/acm-config-server-repo/{{ item }}/*runtime* {{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/{{ item }}
+  loop:
+    - "branding"
+    - "labels"
+    - "ldap"
+    - "lookups"
+    - "rules"
+    - "spring"
+  ignore_errors: true


### PR DESCRIPTION
By doing this we want to make sure that all the runtime files that are inside sub-folders of the acm-config-server-repo are restored from the previous backup to the new deployment configuration