### PR TITLE
Added support for dual ldap (separate ldap for arkcase and portal)

### DIFF
--- a/vagrant/provisioning/arkcase-externalldap-internalsamba.yaml
+++ b/vagrant/provisioning/arkcase-externalldap-internalsamba.yaml
@@ -1,0 +1,59 @@
+---
+- hosts: localhost
+  roles:
+    - role: common
+      tags: [core, common]
+    - role: pki_client
+      tags: [core, pki_client]
+    - role: samba
+      tags: [core, samba]
+    - role: ldap-portal
+      tags: [core, ldap]
+    - role: mariadb
+      tags: [core, mariadb]
+    - role: httpd
+      tags: [core, httpd]
+    - role: haproxy
+      tags: [core, haproxy]
+    - role: activemq
+      tags: [core, activemq]
+    - role: alfresco-setup
+      tags: [core, alfresco, alfresco-setup]
+    - role: alfresco-ce
+      tags: [core, alfresco, alfresco-ee]
+    - role: alfresco
+      tags: [core, alfresco]
+    - role: alfresco-site
+      tags: [core, alfresco, alfresco-site]
+    - role: solr
+      tags: [core, solr]
+    - role: pentaho-setup
+      tags: [core, pentaho, pentaho-setup]
+    - role: pentaho-ee
+      tags: [core, pentaho, pentaho-ee]
+    - role: pentaho-configuration
+      tags: [core, pentaho, pentaho-configuration]
+    - role: snowbound
+      tags: [core, snowbound]
+    - role: snowbound-app
+      tags: [core, snowbound, snowbound-app]
+    - role: pentaho-license
+      tags: [core, pentaho, pentaho-license]
+    - role: arkcase-prerequisites
+      tags: [core, arkcase]
+    - role: arkcase-app
+      tags: [core, arkcase]
+    - role: foia
+      tags: [core, foia]
+    - role: pentaho-pdi-client
+      tags: [core, foia, foia-analytical-reports]
+    - role: foia-analytical-reports
+      tags: [core, foia, foia-analytical-reports]
+    - role: tesseract
+      tags: [core, arkcase, tesseract]
+    - role: firewall
+      tags: [core, firewall]
+    - role: start-arkcase
+      tags: [core, arkcase]
+    
+

--- a/vagrant/provisioning/arkcase-externalldap-internalsamba.yaml
+++ b/vagrant/provisioning/arkcase-externalldap-internalsamba.yaml
@@ -1,8 +1,10 @@
 ---
-- hosts: localhost
+- hosts: all
   roles:
     - role: common
       tags: [core, common]
+    - role: pki
+      tags: [core, pki]  
     - role: pki_client
       tags: [core, pki_client]
     - role: samba
@@ -43,6 +45,8 @@
       tags: [core, arkcase]
     - role: arkcase-app
       tags: [core, arkcase]
+    - role: start-arkcase
+      tags: [core, arkcase]
     - role: foia
       tags: [core, foia]
     - role: pentaho-pdi-client
@@ -53,7 +57,3 @@
       tags: [core, arkcase, tesseract]
     - role: firewall
       tags: [core, firewall]
-    - role: start-arkcase
-      tags: [core, arkcase]
-    
-

--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -401,12 +401,12 @@
       copy:
         dest: "{{ root_folder }}/app/alfresco/shared/classes/alfresco/extension/subsystems/Authentication/ldap-ad/ldap2/ldap-ad.properties"
         content: |
-          ldap.authentication.java.naming.provider.url={{ ldap_url }}
-          ldap.synchronization.java.naming.security.principal={{ ldap_bind_user }}
-          ldap.synchronization.java.naming.security.credentials={{ ldap_bind_password }}
+          ldap.authentication.java.naming.provider.url={{ ldap_portal_url | default(ldap_url) }}
+          ldap.synchronization.java.naming.security.principal={{ ldap_portal_bind_user | default(ldap_bind_user) }}
+          ldap.synchronization.java.naming.security.credentials={{ ldap_portal_bind_password | default(ldap_bind_password) }}
           ldap.synchronization.groupSearchBase={{ ldap_portal_group_no_base }},{{ ldap_base }}
           ldap.synchronization.userSearchBase={{ ldap_portal_user_no_base }},{{ ldap_base }}
-          ldap.authentication.userNameFormat=%s@{{ active_directory_domain }}
+          ldap.authentication.userNameFormat=%s@{{ ldap_portal_user_domain | default(active_directory_domain) }}
   when: foia_portal_context is defined        
 
 - name: configure alfresco.log location

--- a/vagrant/provisioning/roles/foia/tasks/main.yml
+++ b/vagrant/provisioning/roles/foia/tasks/main.yml
@@ -113,6 +113,16 @@
     dest: "{{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/arkcase-portal-server.yaml"
   when: arkcase_version == "" or arkcase_version is version('2020.16', '>=')
 
+
+- name: encrypt passwords
+  include_tasks: encrypt_password.yml
+  loop:
+      - name: ldap_portal_bind_password
+        value: "{{ ldap_portal_bind_password }}"
+  loop_control:
+    loop_var: p
+  when: ldap_portal_bind_password is defined
+
 - name: configure LDAP
   include_role: 
     name: arkcase-ldap-config
@@ -126,7 +136,12 @@
     ldap_template_name: "spring-config-foiaportal-ldap.xml"
     group_base: "{{ ldap_portal_group_no_base | default(ldap_group_no_base) }}"
     user_base: "{{ ldap_portal_user_no_base | default(ldap_user_no_base) }}"
-  when: encrypted_ldap_bind_password is defined
+    ldap_base: "{{ ldap_portal_base | default(ldap_base) }}"
+    ldap_bind_user: "{{ ldap_portal_bind_user | default(ldap_bind_user) }}"
+    encrypted_ldap_bind_password: "ENC({{ encrypted_ldap_portal_bind_password | default(encrypted_ldap_bind_password) }})"
+    ldap_url: "{{ ldap_portal_url | default(ldap_url) }}"
+    ldap_user_domain: "{{ ldap_portal_user_domain | default(ldap_user_domain) }}"
+  when: encrypted_ldap_bind_password is defined or encrypted_ldap_portal_bind_password is defined
 
 - name: copy key store and trust store
   become: yes

--- a/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
+++ b/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
@@ -12,10 +12,10 @@ portal:
   id: "{{ foia_portal_id }}"
   url: "https://{{ external_host }}/{{ foia_portal_context }}"
   arkcaseUrl: "https://{{ internal_host }}/arkcase"
-  groupName: "{{ foia_portal_group }}@{{ ldap_user_domain | upper}}"
+  groupName: "{{ foia_portal_group }}@{{ ldap_portal_user_domain | default(ldap_user_domain) | upper}}"
   # authentication type, possible values (basic, external)
   authenticationType: basic
-  userId: "{{ arkcase_admin_user }}@{{ ldap_user_domain }}"
+  userId: "{{ arkcase_admin_user }}@{{ ldap_portal_user_domain | default(ldap_user_domain) }}"
   password: "{{ arkcase_admin_password }}"
   # portal configuration type
   externalConfiguration: true

--- a/vagrant/provisioning/roles/ldap-portal/tasks/main.yml
+++ b/vagrant/provisioning/roles/ldap-portal/tasks/main.yml
@@ -1,0 +1,78 @@
+- name: LDAP required packages
+  become: yes
+  yum:
+    state: installed
+    name: 
+      - openldap-clients
+      - python-ldap
+
+- name: install pyOpenSSL
+  become: yes
+  pip:
+    name: pyOpenSSL
+
+- name: list certs in the key store
+  become: yes
+  command: keytool -v -list -keystore "{{ java_trust_store }}" -storepass "{{ java_trust_store_pass }}"
+  register: cert_list
+  changed_when: false
+
+- name: import the ldap cert to the ArkCase trust store
+  become: yes
+  java_cert:
+    cert_alias: "arkcase_ldap_cert"
+    cert_url: "{{ ldap_portal_host }}"
+    cert_port: "{{ ldap_portal_port|int }}"
+    keystore_path: "{{ java_trust_store }}"
+    keystore_pass: "{{ java_trust_store_pass }}"
+    state: present
+  when: "'arkcase_ldap_cert' not in cert_list.stdout"
+
+- name: add arkcase ancestors
+  ldap_entry:
+    server_uri: "{{ ldap_portal_url }}"
+    validate_certs: no
+    bind_dn: "{{ ldap_portal_bind_user }}"
+    bind_pw: "{{ ldap_portal_bind_password }}"
+    dn: "{{ item }}"
+    objectClass:
+      - organizationalUnit
+      - top
+    attributes:
+      description: "{{ item }}"
+  loop: "{{ ldap_ancestor_ous }}"
+
+- name: add portal organizational units
+  ldap_entry:
+    server_uri: "{{ ldap_portal_url }}"
+    validate_certs: no
+    bind_dn: "{{ ldap_portal_bind_user }}"
+    bind_pw: "{{ ldap_portal_bind_password }}"
+    dn: "{{ item }}"
+    objectClass:
+      - organizationalUnit
+      - top
+    attributes:
+      description: "{{ item }}"
+  loop:
+    - "{{ ldap_portal_group_no_base }},{{ ldap_portal_base }}"
+    - "{{ ldap_portal_user_no_base }},{{ ldap_portal_base }}"
+  when: foia_portal_context is defined
+
+- name: add portal groups
+  ldap_entry:
+    server_uri: "{{ ldap_portal_url }}"
+    validate_certs: no
+    bind_dn: "{{ ldap_portal_bind_user }}"
+    bind_pw: "{{ ldap_portal_bind_password }}"
+    dn: "CN={{ item.name }},{{ldap_portal_group_no_base}},{{ ldap_portal_base }}"
+    objectClass:
+      - group
+      - top
+    attributes:
+      description: "{{ item.description }}"
+      samAccountName: "{{ item.name }}"
+      cn: "{{ item.name }}"
+  loop: "{{ ldap_portal_groups|flatten }}"
+
+

--- a/vagrant/provisioning/roles/ldap-portal/tasks/main.yml
+++ b/vagrant/provisioning/roles/ldap-portal/tasks/main.yml
@@ -20,13 +20,13 @@
 - name: import the ldap cert to the ArkCase trust store
   become: yes
   java_cert:
-    cert_alias: "arkcase_ldap_cert"
+    cert_alias: "arkcase_ldap_portal_cert"
     cert_url: "{{ ldap_portal_host }}"
     cert_port: "{{ ldap_portal_port|int }}"
     keystore_path: "{{ java_trust_store }}"
     keystore_pass: "{{ java_trust_store_pass }}"
     state: present
-  when: "'arkcase_ldap_cert' not in cert_list.stdout"
+  when: "'arkcase_ldap_portal_cert' not in cert_list.stdout"
 
 - name: add arkcase ancestors
   ldap_entry:


### PR DESCRIPTION
This is the change that is done in order to support 2 ldaps-one for ArkCase(AD) and the other for the FOIA portal(samba)

We need to add these facts:
ldap_portal_base:
ldap_bind_portal_user: 
ldap_portal_bind_password: 
ldap_portal_url: 
ldap_portal_user_domain: