### PR TITLE
changed the portal authenticated mode for 2020.16

### DIFF
--- a/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
+++ b/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
@@ -19,7 +19,7 @@ portal:
   password: "{{ arkcase_admin_password }}"
   # portal configuration type
   externalConfiguration: true
-  authenticatedMode: false
+  authenticatedMode: {{ portal_authenticated_mode | default (false) }}
   activemqUrl: "ssl://{{ activemq_host }}:61616"
   serviceProvider:
     directory.name: "foiaportal"


### PR DESCRIPTION
We have omitted this template but now it should be fixed