### PR TITLE
The task for removing decrypted symmetric key should be presented in the foia role

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -49,6 +49,7 @@
   file:
     path: "{{ root_folder }}/common/symmetricKey.decrypted"
     state: absent
+  when: not foia_portal_context is defined
 
 - name: remove the decrypted symmetric key with new line
   become: yes

--- a/vagrant/provisioning/roles/foia/tasks/main.yml
+++ b/vagrant/provisioning/roles/foia/tasks/main.yml
@@ -113,7 +113,6 @@
     dest: "{{ root_folder }}/data/arkcase-home/.arkcase/acm/acm-config-server-repo/arkcase-portal-server.yaml"
   when: arkcase_version == "" or arkcase_version is version('2020.16', '>=')
 
-
 - name: encrypt passwords
   include_tasks: encrypt_password.yml
   loop:
@@ -122,6 +121,12 @@
   loop_control:
     loop_var: p
   when: ldap_portal_bind_password is defined
+
+- name: remove the decrypted symmetric key
+  become: yes
+  file:
+    path: "{{ root_folder }}/common/symmetricKey.decrypted"
+    state: absent
 
 - name: Set ldap_portal_base
   set_fact:


### PR DESCRIPTION
After we added encrypt_password.yml into foia role, we should somehow remove the deletion of decrypted symmetric key from roles/arkcase-app/tasks/main.yml and include it into roles/foia/tasks/main.yml