### PR TITLE
Removed the foia-analytical-reports

### DIFF
--- a/vagrant/provisioning/arkcase-ee-external-ldap-core-pki.yml
+++ b/vagrant/provisioning/arkcase-ee-external-ldap-core-pki.yml
@@ -45,10 +45,6 @@
       tags: [core, arkcase]
     - role: start-arkcase
       tags: [core, arkcase]
-    - role: pentaho-pdi-client
-      tags: [core, foia, foia-analytical-reports]
-    - role: foia-analytical-reports
-      tags: [core, foia, foia-analytical-reports]
     - role: tesseract
       tags: [core, arkcase, tesseract]
     - role: firewall


### PR DESCRIPTION
I am not sure that we need the foia analytical reports for the ArkCase EE Core version so I am removing them from the playbook for now.