### PR TITLE
Removed task for upgrading 'python-pip'

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -57,14 +57,6 @@
     path: "{{ root_folder }}/common/symmetricKeyWithNewLine.decrypted"
     state: absent
 
-# might have to upgrade PIP itself before installing openpyxl
-- name: update PIP if necessary
-  become: yes
-  pip:      
-    name:
-      - pip
-    extra_args: --upgrade
-
 - name: install Python Excel module
   become: yes
   pip:


### PR DESCRIPTION
I think we don't have to upgrade python2-pip before installing Python Excel module (openpyxl) since it will be installed with pip3. 
The upgrade itself causes additional issues