### PR TITLE
Added Passwords to never expire on samba

### DIFF
--- a/vagrant/provisioning/roles/ldap/tasks/main.yml
+++ b/vagrant/provisioning/roles/ldap/tasks/main.yml
@@ -130,5 +130,10 @@
   include_tasks: add-user.yml
   loop: "{{ ldap_users }}"    
   loop_control:
-    loop_var: u  
+    loop_var: u 
+
+- name: Make sure Samba passwords never expire
+  become: yes
+  command: '{{ root_folder }}/app/samba/bin/samba-tool domain passwordsettings set --max-pwd-age=0'
+  when: ldap_type == "samba"
 


### PR DESCRIPTION
I have added the task to make all the users that are under samba to set their passwords to never expired and added a when condition so that this task should be run only when we have samba setup as ldap as opposed to AD