### PR TITLE
Modify the installer to use cryptography module instead of pyOpenSSL

### DIFF
--- a/vagrant/provisioning/roles/ldap-portal/tasks/main.yml
+++ b/vagrant/provisioning/roles/ldap-portal/tasks/main.yml
@@ -6,10 +6,10 @@
       - openldap-clients
       - python-ldap
 
-- name: install pyOpenSSL
+- name: install cryptography
   become: yes
   pip:
-    name: pyOpenSSL
+    name: cryptography
 
 - name: list certs in the key store
   become: yes

--- a/vagrant/provisioning/roles/ldap/tasks/main.yml
+++ b/vagrant/provisioning/roles/ldap/tasks/main.yml
@@ -6,10 +6,10 @@
       - openldap-clients
       - python-ldap
 
-- name: install pyOpenSSL
+- name: install cryptography
   become: yes
   pip:
-    name: pyOpenSSL
+    name: cryptography
 
 - name: list certs in the key store
   become: yes

--- a/vagrant/provisioning/roles/pki/tasks/main.yml
+++ b/vagrant/provisioning/roles/pki/tasks/main.yml
@@ -1,7 +1,7 @@
-- name: install pyOpenSSL
+- name: install cryptography
   become: yes
   pip:
-    name: pyOpenSSL
+    name: cryptography
 
 - name: create pki folder structure
   become: yes
@@ -22,7 +22,7 @@
     path: "/etc/tls/private/arkcase-root-passphrase.pem"
     type: RSA
     size: 4096
-    cipher: "AES-256-ECB"
+    cipher: "auto"
     passphrase: "m0rn1ngD$w"
 
 - name: remove passphrase from private key
@@ -69,7 +69,7 @@
     path: "/etc/tls/private/arkcase-intermediate-pp.pem"
     type: RSA
     size: 4096
-    cipher: "AES-256-ECB"
+    cipher: "auto"
     passphrase: "m0rn1ngD$w"
   register: intermediate_private_key
 
@@ -133,7 +133,7 @@
     type: RSA
     size: 2048
     mode: 0644
-    cipher: "AES-256-ECB"
+    cipher: "auto"
     passphrase: "m0rn1ngD$w"
   register: server_private_key
 

--- a/vagrant/provisioning/roles/pki_client/tasks/main.yml
+++ b/vagrant/provisioning/roles/pki_client/tasks/main.yml
@@ -1,7 +1,7 @@
-- name: install pyOpenSSL
+- name: install cryptography
   become: yes
   pip:
-    name: pyOpenSSL
+    name: cryptography
 
 - name: see if rsa private key exists
   stat:


### PR DESCRIPTION
Modifying the installer to use python cryptography module instead of pyOpenSSL because the installer crashed every time with the newer versions of ansible and as a recommendation we switch to cryptography module. 
