### PR TITLE
Added select_crypto_backend to use cryptography

### DIFF
--- a/vagrant/provisioning/roles/pki/tasks/main.yml
+++ b/vagrant/provisioning/roles/pki/tasks/main.yml
@@ -24,6 +24,7 @@
     size: 4096
     cipher: "auto"
     passphrase: "m0rn1ngD$w"
+    select_crypto_backend: "cryptography"
 
 - name: remove passphrase from private key
   become: yes


### PR DESCRIPTION
As we are replacing pyOpenSSL with cryptography we need to instruct ansible to use cryptography in this task