### PR TITLE
Add default empty value for aws encryption variables

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -42,9 +42,9 @@
       - name: ldap_bind_password
         value: "{{ ldap_bind_password }}"
       - name: aws_access_key_id
-        value: "{{ aws_access_key_id }}"
+        value: "{{ aws_access_key_id | default('') }}"
       - name: aws_secret_access_key
-        value: "{{ aws_secret_access_key }}"
+        value: "{{ aws_secret_access_key | default('') }}"
   loop_control:
     loop_var: p
 


### PR DESCRIPTION
The installer is failing now per DSO-341. Let's see if this will fix the issue