### PR TITLE
Added a default value for zylab_server_host

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -451,7 +451,7 @@
   become: yes
   java_cert:
     cert_alias: "zylab_server_cert"
-    cert_url: "{{ zylab_server_host }}"
+    cert_url: "{{ zylab_server_host | default('') }}"
     cert_port: "{{ zylab_server_port|int }}"
     keystore_path: "{{ java_trust_store }}"
     keystore_pass: "{{ java_trust_store_pass }}"

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -451,12 +451,12 @@
   become: yes
   java_cert:
     cert_alias: "zylab_server_cert"
-    cert_url: "{{ zylab_server_host | default('') }}"
+    cert_url: "{{ zylab_server_host }}"
     cert_port: "{{ zylab_server_port|int }}"
     keystore_path: "{{ java_trust_store }}"
     keystore_pass: "{{ java_trust_store_pass }}"
     state: present
-  when: zylab_integration_enabled is defined AND zylab_integration_enabled | default(false) and 'zylab_server_cert' not in cert_list.stdout
+  when: zylab_integration_enabled is defined AND zylab_integration_enabled | default(false) and 'zylab_server_cert' not in cert_list.stdout and zylab_server_host is defined
   
 # NOTE keep the /home/arkcase/.arkcase file names the
 # same until next release


### PR DESCRIPTION
if we don't have zylab_server_host defined the installer fails now it will pickup a default empty value