### PR TITLE
Modify the installer to change the default Alfresco password

### DIFF
--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -376,8 +376,8 @@ default_database_password: "@rKc@3S!"
 tomcat_major_version: 9
 tomcat_version: 9.0.22
 
-# Set Alfresco Admin password
-alfresco_admin_password: "{{ arkcase_admin_password }}" 
+# use more complicated password for Alfresco admin user before you start with the installation
+alfresco_admin_password: "admin"
 
 # Alfresco Community Edition
 alfresco_release_name: 201806-GA

--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -376,6 +376,9 @@ default_database_password: "@rKc@3S!"
 tomcat_major_version: 9
 tomcat_version: 9.0.22
 
+# Set Alfresco Admin password
+alfresco_admin_password: "{{ arkcase_admin_password }}" 
+
 # Alfresco Community Edition
 alfresco_release_name: 201806-GA
 alfresco_build_number: "-build-00113"

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -461,6 +461,9 @@ default_database_password: "@rM3d1A!"
 tomcat_major_version: 9
 tomcat_version: 9.0.22
 
+# Set Alfresco Admin password
+alfresco_admin_password: "{{ arkcase_admin_password }}"
+
 # Alfresco Community Edition
 alfresco_release_name: 201806-GA
 alfresco_build_number: "-build-00113"

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -461,8 +461,8 @@ default_database_password: "@rM3d1A!"
 tomcat_major_version: 9
 tomcat_version: 9.0.22
 
-# Set Alfresco Admin password
-alfresco_admin_password: "{{ arkcase_admin_password }}"
+# use more complicated password for Alfresco admin user before you start with the installation
+alfresco_admin_password: "admin"
 
 # Alfresco Community Edition
 alfresco_release_name: 201806-GA

--- a/vagrant/provisioning/arkcase-dev-microservices-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-microservices-facts.yml
@@ -461,6 +461,9 @@ default_database_password: "@rM3d1A!"
 tomcat_major_version: 9
 tomcat_version: 9.0.22
 
+# use more complicated password for Alfresco admin user before you start with the installation
+alfresco_admin_password: "admin"
+
 # Alfresco Community Edition
 alfresco_release_name: 201806-GA
 alfresco_build_number: "-build-00113"

--- a/vagrant/provisioning/roles/alfresco-site/tasks/create-category.yml
+++ b/vagrant/provisioning/roles/alfresco-site/tasks/create-category.yml
@@ -3,7 +3,7 @@
     url: '{{ alfresco_url }}/alfresco/s/api/type/rma{{ ":" }}recordCategory/formprocessor'
     method: POST
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: false
     body_format: json
     body:

--- a/vagrant/provisioning/roles/alfresco-site/tasks/create-site.yml
+++ b/vagrant/provisioning/roles/alfresco-site/tasks/create-site.yml
@@ -1,5 +1,5 @@
 - name: create {{ s_name }} share site
-  command: curl -k -sS --user admin:admin -H 'Content-Type{{ ":" }} application/json' -H 'Accept{{ ":" }} */*' -H 'Alfresco-CSRFToken{{ ":" }} {{ s_csrftoken }}' --cookie cookie.txt --cookie-jar cookie.txt -X POST '{{ alfresco_url }}/share/service/modules/create-site' --data '{ "title"{{ ":" }} "{{ s_title }}","shortName"{{ ":" }} "{{ s_name }}","description"{{ ":" }} "{{ s_description }}","sitePreset"{{ ":" }} "{{ s_preset }}", "type"{{ ":" }} "{{ s_type }}","visibility"{{ ":" }} "PUBLIC","compliance"{{ ":" }} "{{ s_compliance }}" }' --compressed
+  command: curl -k -sS --user admin:"{{ alfresco_admin_password }}" -H 'Content-Type{{ ":" }} application/json' -H 'Accept{{ ":" }} */*' -H 'Alfresco-CSRFToken{{ ":" }} {{ s_csrftoken }}' --cookie cookie.txt --cookie-jar cookie.txt -X POST '{{ alfresco_url }}/share/service/modules/create-site' --data '{ "title"{{ ":" }} "{{ s_title }}","shortName"{{ ":" }} "{{ s_name }}","description"{{ ":" }} "{{ s_description }}","sitePreset"{{ ":" }} "{{ s_preset }}", "type"{{ ":" }} "{{ s_type }}","visibility"{{ ":" }} "PUBLIC","compliance"{{ ":" }} "{{ s_compliance }}" }' --compressed
   args:
     warn: false
   register: acm_site_out

--- a/vagrant/provisioning/roles/alfresco-site/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco-site/tasks/main.yml
@@ -20,7 +20,7 @@
     
 # note, can't use get_uri here since we need to keep the cookie jar
 - name: login to Share
-  command: curl -k -sS --user admin:admin --cookie cookie.txt --cookie-jar cookie.txt -H "Content-Type:application/x-www-form-urlencoded" --data "success=/share/page/" --data "failure=/share/page/?error=true" --data "username=admin" --data "password=admin" -X POST "{{ alfresco_url }}/share/page/dologin"
+  command: curl -k -sS --user admin:"{{ alfresco_admin_password }}" --cookie cookie.txt --cookie-jar cookie.txt -H "Content-Type:application/x-www-form-urlencoded" --data "success=/share/page/" --data "failure=/share/page/?error=true" --data "username=admin" --data password="{{ alfresco_admin_password }}" -X POST "{{ alfresco_url }}/share/page/dologin"
   args:
     warn: false
   changed_when: false
@@ -32,7 +32,7 @@
   changed_when: false
 
 - name: get the CSRFToken
-  command: curl -k -sS --user admin:admin --cookie cookie.txt --cookie-jar cookie.txt "{{ alfresco_url }}/share/service/modules/authenticated?a=user"
+  command: curl -k -sS --user admin:"{{ alfresco_admin_password }}" --cookie cookie.txt --cookie-jar cookie.txt "{{ alfresco_url }}/share/service/modules/authenticated?a=user"
   args:
     warn: false
   changed_when: false
@@ -67,7 +67,7 @@
   uri:
     url: "{{ alfresco_url }}/alfresco/s/slingshot/doclib/container/acm/documentlibrary"
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
     return_content: yes
   register: doclib_out
@@ -77,7 +77,7 @@
   uri:
     url: "{{ alfresco_url }}/alfresco/s/slingshot/doclib/treenode/site/acm/documentLibrary?perms=false&children=false&max=1000"
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
     return_content: yes
   register: existing_folders_out
@@ -88,7 +88,7 @@
     method: POST
     timeout: 120
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
     return_content: yes
     body_format: json
@@ -116,7 +116,7 @@
     url: "{{ alfresco_url }}/alfresco/s/slingshot/doclib/containers/rm"
     validate_certs: false
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
   register: rm_container_out
 
 # the join filter is just to lift the only array member into a string...
@@ -138,7 +138,7 @@
   uri:
     url: "{{ alfresco_url }}/alfresco/s/slingshot/doclib/treenode/site/rm/documentLibrary?perms=false&children=false&max=1000"
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
   register: rm_existing_folders_out
 
@@ -160,7 +160,7 @@
     url: "{{ alfresco_url }}/alfresco/s/api/sites/acm/memberships"
     method: POST
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
     return_content: yes
     body_format: json
@@ -177,7 +177,7 @@
     url: "{{ alfresco_url }}/alfresco/s/api/rm/roles/{{ item.alfresco_rma_role}}/authorities/GROUP_{{ item.name | urlencode }}"
     method: POST
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
     return_content: yes
     body_format: json
@@ -191,7 +191,7 @@
     url: "{{ alfresco_url }}/alfresco/s/api/sites/rm/memberships"
     method: POST
     user: admin
-    password: admin
+    password: "{{ alfresco_admin_password }}"
     validate_certs: no
     return_content: yes
     body_format: json

--- a/vagrant/provisioning/roles/alfresco/files/passencode.py
+++ b/vagrant/provisioning/roles/alfresco/files/passencode.py
@@ -4,6 +4,6 @@ import bcrypt
 import sys
 
 passwd = sys.argv[1]
-salt = bcrypt.gensalt(rounds=10)
-hashed = bcrypt.hashpw(passwd, salt)
+b = passwd.encode('utf-8')
+hashed = bcrypt.hashpw(b, bcrypt.gensalt(rounds=10)).decode('utf-8')
 print(hashed.replace("$2b$","$2a$"))

--- a/vagrant/provisioning/roles/alfresco/files/passencode.py
+++ b/vagrant/provisioning/roles/alfresco/files/passencode.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import bcrypt
+import sys
+
+passwd = sys.argv[1]
+salt = bcrypt.gensalt(rounds=10)
+hashed = bcrypt.hashpw(passwd, salt)
+print(hashed.replace("$2b$","$2a$"))

--- a/vagrant/provisioning/roles/alfresco/files/passencrypt.py
+++ b/vagrant/provisioning/roles/alfresco/files/passencrypt.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-import sys
-import hashlib
-passwd = sys.argv[1]
-passwd.encode('utf-16le')
-print hashlib.new('md4', passwd.encode('utf-16le')).hexdigest()

--- a/vagrant/provisioning/roles/alfresco/files/passencrypt.py
+++ b/vagrant/provisioning/roles/alfresco/files/passencrypt.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import sys
+import hashlib
+passwd = sys.argv[1]
+passwd.encode('utf-16le')
+print hashlib.new('md4', passwd.encode('utf-16le')).hexdigest()

--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -262,6 +262,16 @@
   shell: rpm -ql ImageMagick | grep modules | grep coders | awk -F / '{ print $5 }' | sort -u
   register: imagemagick_modules
 
+- name: check Alfresco is active
+  shell: systemctl status alfresco.service | grep Active | awk -v N=2 '{print $N}'
+  register: output
+
+- name: stop Alfresco to add new items in alfresco-global.properties
+  service:
+    name: alfresco
+    state: stopped
+  when: output.stdout == 'active'
+
 - name: populate alfresco-global.properties
   become: yes
   become_user: alfresco
@@ -277,6 +287,7 @@
       synchronization.syncWhenMissingPeopleLogIn=true
       synchronization.autoCreatePeopleOnLogin=false
       synchronization.import.cron=0 0/5 * * * ? *
+      system.preferred.password.encoding=bcrypt10
       csrf.filter.enabled=false
       dir.root={{ root_folder }}/data/alfresco/alf_data
       db.name=alfresco
@@ -473,24 +484,6 @@
         chdir: "{{ root_folder }}/tmp/alfresco"
       when: share_log4j_updated is changed
 
-- name: Run Python script to generate the hash
-  script: "passencrypt.py {{ alfresco_admin_password }}"
-  register: pass_hash
-
-- name: Execute required update querry to change default alfresco password
-  command: >
-    mysql -u root -D alfresco -e "UPDATE alf_node_properties SET string_value='{{ pass_hash.stdout | trim }}' WHERE node_id=(SELECT anp1.node_id FROM alf_node_properties anp1 INNER JOIN alf_qname aq1 ON aq1.id = anp1.qname_id INNER JOIN alf_node_properties anp2 ON anp2.node_id = anp1.node_id INNER JOIN alf_qname aq2 ON aq2.id = anp2.qname_id WHERE aq1.local_name = 'password' AND aq2.local_name = 'username' AND anp2.string_value = 'admin') and qname_id=(SELECT anp1.qname_id FROM alf_node_properties anp1 INNER JOIN alf_qname aq1 ON aq1.id = anp1.qname_id INNER JOIN alf_node_properties anp2 ON anp2.node_id = anp1.node_id INNER JOIN alf_qname aq2 ON aq2.id = anp2.qname_id WHERE aq1.local_name = 'password' AND aq2.local_name = 'username' AND anp2.string_value = 'admin');"
-
-- name: Check Alfresco if active
-  shell: systemctl status alfresco.service | grep Active | awk -v N=2 '{print $N}'
-  register: output
-
-- name: Stop Alfresco to accept password change
-  service:
-    name: alfresco
-    state: stopped
-  when: output.stdout == 'active'
-
 - name: Alfresco systemd unit file
   become: yes
   template:
@@ -516,6 +509,25 @@
     daemon_reload: true
     name: alfresco
     state: started
+
+- name: install bcrypt for hashing
+  become: yes
+  pip:
+    name: bcrypt
+
+- name: run Python script to generate the hash
+  script: "passencode.py {{ alfresco_admin_password }}"
+  register: pass_hash
+
+- name: execute required update querry to change default alfresco password
+  command: >
+    mysql -u root -D alfresco -e "UPDATE alf_node_properties SET string_value='{{ pass_hash.stdout | trim }}' WHERE node_id=(SELECT anp1.node_id FROM alf_node_properties anp1 INNER JOIN alf_qname aq1 ON aq1.id = anp1.qname_id INNER JOIN alf_node_properties anp2 ON anp2.node_id = anp1.node_id INNER JOIN alf_qname aq2 ON aq2.id = anp2.qname_id WHERE aq1.local_name = 'passwordHash' AND aq2.local_name = 'username' AND anp2.string_value = 'admin') and qname_id=(SELECT anp1.qname_id FROM alf_node_properties anp1 INNER JOIN alf_qname aq1 ON aq1.id = anp1.qname_id INNER JOIN alf_node_properties anp2 ON anp2.node_id = anp1.node_id INNER JOIN alf_qname aq2 ON aq2.id = anp2.qname_id WHERE aq1.local_name = 'passwordHash' AND aq2.local_name = 'username' AND anp2.string_value = 'admin');"
+
+- name: restart Alfresco
+  become: yes
+  systemd:
+    name: alfresco
+    state: restarted
 
 - name: wait for Alfresco startup to finish
   wait_for:

--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -472,8 +472,25 @@
       args:
         chdir: "{{ root_folder }}/tmp/alfresco"
       when: share_log4j_updated is changed
-      
-      
+
+- name: Run Python script to generate the hash
+  script: "passencrypt.py {{ alfresco_admin_password }}"
+  register: pass_hash
+
+- name: Execute required update querry to change default alfresco password
+  command: >
+    mysql -u root -D alfresco -e "UPDATE alf_node_properties SET string_value='{{ pass_hash.stdout | trim }}' WHERE node_id=(SELECT anp1.node_id FROM alf_node_properties anp1 INNER JOIN alf_qname aq1 ON aq1.id = anp1.qname_id INNER JOIN alf_node_properties anp2 ON anp2.node_id = anp1.node_id INNER JOIN alf_qname aq2 ON aq2.id = anp2.qname_id WHERE aq1.local_name = 'password' AND aq2.local_name = 'username' AND anp2.string_value = 'admin') and qname_id=(SELECT anp1.qname_id FROM alf_node_properties anp1 INNER JOIN alf_qname aq1 ON aq1.id = anp1.qname_id INNER JOIN alf_node_properties anp2 ON anp2.node_id = anp1.node_id INNER JOIN alf_qname aq2 ON aq2.id = anp2.qname_id WHERE aq1.local_name = 'password' AND aq2.local_name = 'username' AND anp2.string_value = 'admin');"
+
+- name: Check Alfresco if active
+  shell: systemctl status alfresco.service | grep Active | awk -v N=2 '{print $N}'
+  register: output
+
+- name: Stop Alfresco to accept password change
+  service:
+    name: alfresco
+    state: stopped
+  when: output.stdout == 'active'
+
 - name: Alfresco systemd unit file
   become: yes
   template:

--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -513,6 +513,7 @@
 - name: install bcrypt for hashing
   become: yes
   pip:
+    executable: pip3
     name: bcrypt
 
 - name: run Python script to generate the hash

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -23,8 +23,8 @@
         value: "{{ default_database_password }}"
       - name: default_user
         value: "{{ default_user_password }}"
-      - name: default_alfresco
-        value: admin
+      - name: alfresco_admin_password
+        value: "{{ alfresco_admin_password }}"
       - name: old_default_user
         value: AcMd3v$
       - name: activemq_guest
@@ -586,9 +586,9 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1/xhPRpzw95iNfLBLwieucwbQ0eg9woLOk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX1/ADLCgdmaKs9V7jL58/2khwFbgqAY7jVE=."
-      replace: "ENC{{ encrypted_default_alfresco }})"
+      replace: "ENC{{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
@@ -630,9 +630,9 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1/xhPRpzw95iNfLBLwieucwbQ0eg9woLOk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX1/ADLCgdmaKs9V7jL58/2khwFbgqAY7jVE=."
-      replace: "ENC{{ encrypted_default_alfresco }})"
+      replace: "ENC{{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
@@ -660,9 +660,9 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1/xhPRpzw95iNfLBLwieucwbQ0eg9woLOk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX1/ADLCgdmaKs9V7jL58/2khwFbgqAY7jVE=."
-      replace: "ENC{{ encrypted_default_alfresco }})"
+      replace: "ENC{{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
@@ -672,7 +672,7 @@
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
       replace: "ENC({{ encrypted_snowbound_key }})"
     - regexp: "ENC.U2FsdGVkX1.xMlwqvI2wwoWYIw6.wL6WMU3T4UfpKPk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
   when: camel_alfresco_cmis_properties.stat.exists
 
 - name: see if we have a camel opencmis cmis properties file
@@ -693,9 +693,9 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1/xhPRpzw95iNfLBLwieucwbQ0eg9woLOk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX1/ADLCgdmaKs9V7jL58/2khwFbgqAY7jVE=."
-      replace: "ENC{{ encrypted_default_alfresco }})"
+      replace: "ENC{{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
@@ -705,7 +705,7 @@
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
       replace: "ENC({{ encrypted_snowbound_key }})"
     - regexp: "ENC.U2FsdGVkX1.xMlwqvI2wwoWYIw6.wL6WMU3T4UfpKPk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
   when: camel_open_cmis_properties.stat.exists
 
 
@@ -737,9 +737,9 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1/xhPRpzw95iNfLBLwieucwbQ0eg9woLOk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX1/ADLCgdmaKs9V7jL58/2khwFbgqAY7jVE=."
-      replace: "ENC{{ encrypted_default_alfresco }})"
+      replace: "ENC{{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
@@ -749,7 +749,7 @@
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
       replace: "ENC({{ encrypted_snowbound_key }})"
     - regexp: "ENC.U2FsdGVkX1.xMlwqvI2wwoWYIw6.wL6WMU3T4UfpKPk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
   when: alfresco_cmis_properties.stat.exists
 
 - name: see if we have an opencmis cmis properties file
@@ -770,9 +770,9 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1/xhPRpzw95iNfLBLwieucwbQ0eg9woLOk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX1/ADLCgdmaKs9V7jL58/2khwFbgqAY7jVE=."
-      replace: "ENC{{ encrypted_default_alfresco }})"
+      replace: "ENC{{ encrypted_alfresco_admin_password }})"
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
@@ -782,7 +782,7 @@
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
       replace: "ENC({{ encrypted_snowbound_key }})"
     - regexp: "ENC.U2FsdGVkX1.xMlwqvI2wwoWYIw6.wL6WMU3T4UfpKPk=."
-      replace: "ENC({{ encrypted_default_alfresco }})"
+      replace: "ENC({{ encrypted_alfresco_admin_password }})"
   when: open_cmis_properties.stat.exists
 
 # this template includes encrypted passwords


### PR DESCRIPTION
Currently the default Alfresco password is left when we install Alfresco and we need to modify the installer to change the password upon installation. 