### PR TITLE
Create cronjob in the installer to remove all files older than one week

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -111,3 +111,14 @@
 - name: Set default locale to en_US.utf8
   become: yes
   command: localectl set-locale LANG=en_US.utf8
+
+- name: Run CRON job every day at 1.05 to remove files older than 7 days
+  become: yes
+  become_method: sudo
+  cron:
+    name: "remove_files"
+    user: "root"
+    hour: "1"
+    minute: "5"
+    job: 'find {{ root_folder }}/data/arkcase-home/fileserver -mtime +6 -type f -exec rm {} \;'
+    state: present


### PR DESCRIPTION
The fileserver folder (arkcase/data/arkcase-home/fileserver) is used to transfer files to and from ActiveMQ.  Files are added there, but never removed.
