### PR TITLE
Add facts for ActiveMQ authentication user and password

### DIFF
--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -480,3 +480,7 @@ email_receiver_complaint_password: ""
 email_receiver_consultation_account: ""
 email_receiver_consultation_account_escaped: "{{ email_receiver_consultation_account | replace('@', '%40') }}"
 email_receiver_consultation_password: ""
+
+# define username and password for ActiveMQ authentication between apps
+activemq_user: ""
+activemq_password: ""

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -571,3 +571,7 @@ email_receiver_complaint_password: ""
 email_receiver_consultation_account: ""
 email_receiver_consultation_account_escaped: "{{ email_receiver_consultation_account | replace('@', '%40') }}"
 email_receiver_consultation_password: ""
+
+# define username and password for ActiveMQ authentication between apps
+activemq_user: ""
+activemq_password: ""

--- a/vagrant/provisioning/roles/activemq/tasks/main.yml
+++ b/vagrant/provisioning/roles/activemq/tasks/main.yml
@@ -170,6 +170,34 @@
         dest: "{{ root_folder }}/app/activemq/lib/mariadb-java-client-{{ mariadb_jdbc_version }}.jar"
         state: link
 
+- name: enable authentication for ActiveMQ in activemq.xml
+  become: yes
+  become_user: activemq
+  blockinfile:
+    path: "{{ root_folder }}/app/activemq/conf/activemq.xml"
+    insertafter: "        </persistenceAdapter>"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: Authentication"
+    block: |
+      <plugins>    
+          <!-- Configure authentication; Username, passwords and groups -->
+          <simpleAuthenticationPlugin>
+              <users>
+                  <authenticationUser username="${activemq.username}" password="${activemq.password}" groups="admins"/>
+                  <authenticationUser username="${arkcase.user}" password="${arkcase.password}" groups="users"/>
+              </users>
+          </simpleAuthenticationPlugin>
+      </plugins>
+
+- name: put authentication credentials in credentials.properties file
+  become: yes
+  become_user: activemq
+  blockinfile:
+    path: "{{ root_folder }}/app/activemq/conf/credentials.properties"
+    insertafter: "# Defines credentials that will be used by components (like web console) to access the broker"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: Authentication"
+    block: |
+      arkcase.user={{ activemq_user | default('guest', true) }}
+      arkcase.password={{ activemq_password | default('guest', true) }}
 
 - name: sslContext in activemq.xml
   become: yes

--- a/vagrant/provisioning/roles/activemq/tasks/main.yml
+++ b/vagrant/provisioning/roles/activemq/tasks/main.yml
@@ -182,7 +182,7 @@
           <!-- Configure authentication; Username, passwords and groups -->
           <simpleAuthenticationPlugin>
               <users>
-                  <authenticationUser username="${arkcase.user}" password="${arkcase.password}" groups="users"/>
+                  <authenticationUser username="${arkcase.user}" password="${arkcase.password}" groups="users,admins"/>
               </users>
           </simpleAuthenticationPlugin>
       </plugins>

--- a/vagrant/provisioning/roles/activemq/tasks/main.yml
+++ b/vagrant/provisioning/roles/activemq/tasks/main.yml
@@ -182,11 +182,11 @@
           <!-- Configure authentication; Username, passwords and groups -->
           <simpleAuthenticationPlugin>
               <users>
-                  <authenticationUser username="${activemq.username}" password="${activemq.password}" groups="admins"/>
                   <authenticationUser username="${arkcase.user}" password="${arkcase.password}" groups="users"/>
               </users>
           </simpleAuthenticationPlugin>
       </plugins>
+  when: arkcase_version == "" or arkcase_version is version('2021.02', '>=')
 
 - name: put authentication credentials in credentials.properties file
   become: yes
@@ -198,6 +198,7 @@
     block: |
       arkcase.user={{ activemq_user | default('guest', true) }}
       arkcase.password={{ activemq_password | default('guest', true) }}
+  when: arkcase_version == "" or arkcase_version is version('2021.02', '>=')
 
 - name: sslContext in activemq.xml
   become: yes

--- a/vagrant/provisioning/roles/arkcase-app/files/arkcase-activemq.yaml
+++ b/vagrant/provisioning/roles/arkcase-app/files/arkcase-activemq.yaml
@@ -12,6 +12,6 @@ ark.activemq:
   #Maximum number of connections to ActiveMQ.
   maxConnections: 10
   #username to connect to the ActiveMQ instance
-  username: "guest"
+  username: "{{ activemq_user | default('guest', true) }}"
   #password for the ActiveMQ user identified by ark.activemq.username
-  password: "guest"
+  password: "ENC({{ encrypted_activemq_password }})"

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -29,6 +29,8 @@
         value: AcMd3v$
       - name: activemq_guest
         value: guest
+      - name: activemq_password
+        value: "{{ activemq_password | default('guest', true) }}"
       - name: snowbound_key
         value: armediaaeskey123
       - name: admin_user_password
@@ -592,7 +594,7 @@
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
     - regexp: "ENC.U2FsdGVkX1/Byxn9VvOcopumBXAHXig.63j4n4SAJ3w=."
       replace: "ENC({{ encrypted_default_database }})"
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
@@ -616,7 +618,7 @@
   loop:
 # note, using dot to match regexp special chars
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
   when: arkcase_activemq_xml.stat.exists
       
 - name: plaintext passwords (forms properties)
@@ -636,7 +638,7 @@
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
     - regexp: "ENC.U2FsdGVkX1/Byxn9VvOcopumBXAHXig.63j4n4SAJ3w=."
       replace: "ENC({{ encrypted_default_database }})"
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
@@ -666,7 +668,7 @@
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
     - regexp: "ENC.U2FsdGVkX1/Byxn9VvOcopumBXAHXig.63j4n4SAJ3w=."
       replace: "ENC({{ encrypted_default_database }})"
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
@@ -699,7 +701,7 @@
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
     - regexp: "ENC.U2FsdGVkX1/Byxn9VvOcopumBXAHXig.63j4n4SAJ3w=."
       replace: "ENC({{ encrypted_default_database }})"
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
@@ -743,7 +745,7 @@
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
     - regexp: "ENC.U2FsdGVkX1/Byxn9VvOcopumBXAHXig.63j4n4SAJ3w=."
       replace: "ENC({{ encrypted_default_database }})"
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
@@ -776,7 +778,7 @@
     - regexp: "ENC.U2FsdGVkX18opRRmCattSZiUNjfr598Qq7P3DgZSwGw=."
       replace: "ENC({{ encrypted_old_default_user }})"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
     - regexp: "ENC.U2FsdGVkX1/Byxn9VvOcopumBXAHXig.63j4n4SAJ3w=."
       replace: "ENC({{ encrypted_default_database }})"
     - regexp: "ENC.U2FsdGVkX1./i7RReaawm2OyEcse1DBxZ0.oGE3ZsT5V1ahjvWhorhAZoUB97sHH."
@@ -868,7 +870,7 @@
     - regexp: "acm-arkcase"
       replace: "{{ activemq_host }}"
     - regexp: "ENC.U2FsdGVkX1.SMOIdK/h2Cy5ONteYLksBQnHZllFZcKs=."
-      replace: "ENC({{ encrypted_activemq_guest }})"
+      replace: "ENC({{ encrypted_activemq_password }})"
   when: arkcase_version != "" and arkcase_version is version('3.3.3', '<')
 
 - name: copy arkcase-activemq.yaml if necessary

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -27,8 +27,6 @@
         value: admin
       - name: old_default_user
         value: AcMd3v$
-      - name: activemq_guest
-        value: guest
       - name: activemq_password
         value: "{{ activemq_password | default('guest', true) }}"
       - name: snowbound_key
@@ -340,6 +338,23 @@
     warn: false
   when: tls_default_removed_from_service is changed
 
+- name: application.properties file
+  become: yes
+  become_user: arkcase
+  template:
+    src: application.properties
+    dest: "{{ root_folder }}/app/config-server/application.properties"
+    backup: yes
+
+- name: run config-server with application.properties file
+  become: yes
+  replace:
+    backup: yes
+    path: "/etc/systemd/system/config-server.service"
+    regexp: "Environment=_JAVA_OPTIONS=-Djava.io.tmpdir={{ root_folder }}/data/config-server/tmp"
+    replace: "Environment=_JAVA_OPTIONS=-Djava.io.tmpdir={{ root_folder }}/data/config-server/tmp -Dspring.config.location=/opt/arkcase/app/config-server/application.properties"
+  when: arkcase_version == "" or arkcase_version is version('2021.02', '>=')
+
 - name: enable ArkCase 
   become: yes
   systemd:
@@ -355,7 +370,17 @@
     name: config-server
     enabled: yes
     masked: no
-  
+
+- name: check config-server is active
+  shell: systemctl status config-server.service | grep Active | awk -v N=2 '{print $N}'
+  register: output
+
+- name: restart config-server to bring the changes in the service file
+  service:
+    name: config-server
+    state: restarted
+  when: output.stdout == 'active'
+
 - name: capture current arkcase.yaml
   become: yes
   become_user: arkcase

--- a/vagrant/provisioning/roles/arkcase-app/templates/application.properties
+++ b/vagrant/provisioning/roles/arkcase-app/templates/application.properties
@@ -1,0 +1,34 @@
+server.port: 9999
+spring:
+  profiles.active: native
+  cloud.config.server:
+    native.searchLocations: file:"{{ root_folder }}/app/config-server",file:"{{ root_folder }}/app/config-server/labels",file:"{{ root_folder }}/app/config-server/ldap",file:"{{ root_folder }}/app/config-server/lookups",file:"{{ root_folder }}/app/config-server/rules"
+  jms:
+    pub-sub-domain: true
+properties.folder.path: "{{ root_folder }}/app/config-server"
+branding.files.folder.path: "{{ root_folder }}/app/config-server/branding"
+logging:
+  file.max-history: 10
+  file.max-size: 10MB
+  file: logs/acmConfigServer.log
+  level:
+    com.armedia.acm.configserver: debug
+    org.springframework.cloud.config: debug
+  pattern:
+    file: "%d{yyyy-MM-dd HH:mm:ss,SSS} [%thread] %-5level %logger.%M - %msg%n"
+jms.message.buffer.window: 1
+acm.activemq:
+  broker-url: "ssl://{{ activemq_host }}:61616"
+  keystore: "{{ java_key_store }}"
+  keystore-password: "{{ default_user_password }}"
+  truststore: "{{ java_trust_store }}"
+  truststore-password: "{{ default_user_password }}"
+  user: "{{ activemq_user | default('guest', true) }}"
+  password: "{{ activemq_password | default('guest', true) }}"
+  default-destination: configuration.changed
+  labels-destination: labels.changed
+  ldap-destination: ldap.changed
+  lookups-destination: lookups.changed
+  rules-destination: rules.changed
+  timeout: 10 #seconds
+arkcase.languages: "-de,-en,-en-in,-es,-fr,-hi,-ja,-pt,-ru,-zh-cn,-zh-tw"

--- a/vagrant/provisioning/roles/arkcase-app/templates/application.properties
+++ b/vagrant/provisioning/roles/arkcase-app/templates/application.properties
@@ -10,7 +10,7 @@ branding.files.folder.path: "{{ root_folder }}/app/config-server/branding"
 logging:
   file.max-history: 10
   file.max-size: 10MB
-  file: logs/acmConfigServer.log
+  file: "{{ root_folder }}/log/config-server/acmConfigServer.log"
   level:
     com.armedia.acm.configserver: debug
     org.springframework.cloud.config: debug

--- a/vagrant/provisioning/roles/arkcase-app/templates/server.yml
+++ b/vagrant/provisioning/roles/arkcase-app/templates/server.yml
@@ -144,3 +144,10 @@ payment:
     password: "{{ touchnet_password | default('') }}"
     securelinkendpoint: "{{ touchnet_securelinkendpoint | default('') }}"
     upaysiteid: "{{ touchnet_upaysiteid | default('') }}"
+
+acm.websockets:
+  stomp_broker_relay.client_login: "{{ activemq_user | default('guest', true) }}"
+  stomp_broker_relay.client_passcode: "ENC({{ encrypted_activemq_password }})"
+  #STOMP (ArkCase to ActiveMQ) authentication
+  stomp_broker_relay.system_login: "{{ activemq_user | default('guest', true) }}"
+  stomp_broker_relay.system_passcode: "ENC({{ encrypted_activemq_password }})"

--- a/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
+++ b/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
@@ -30,3 +30,5 @@ portal:
   security.authentication:
     header.parameter.name: foia-api-secret
     token:  "{{ portal_foiagov_token | default ('') }}"
+  userName: "{{ activemq_user | default('guest', true) }}"
+  password: "ENC({{ encrypted_activemq_password }})"

--- a/vagrant/provisioning/roles/foia/templates/foia.yml
+++ b/vagrant/provisioning/roles/foia/templates/foia.yml
@@ -8,7 +8,7 @@ gov.foia.broker:
   truststore: "{{ java_trust_store }}"
   truststore.password: "{{ java_trust_store_pass }}"
   file_upload_url: "file:///${user.home}/fileserver/"
-  userName: "guest"￼
+  userName: "guest"
   password: "guest"
 application:
   properties:

--- a/vagrant/provisioning/roles/foia/templates/foia.yml
+++ b/vagrant/provisioning/roles/foia/templates/foia.yml
@@ -8,8 +8,8 @@ gov.foia.broker:
   truststore: "{{ java_trust_store }}"
   truststore.password: "{{ java_trust_store_pass }}"
   file_upload_url: "file:///${user.home}/fileserver/"
-  userName: "guest"
-  password: "guest"
+  userName: "{{ activemq_user | default('guest', true) }}"
+  password: "ENC({{ encrypted_activemq_password }})"
 application:
   properties:
     basePortalUrl: "https://{{ external_host }}/{{ foia_portal_context }}"

--- a/vagrant/provisioning/roles/foia/templates/foia.yml
+++ b/vagrant/provisioning/roles/foia/templates/foia.yml
@@ -8,6 +8,8 @@ gov.foia.broker:
   truststore: "{{ java_trust_store }}"
   truststore.password: "{{ java_trust_store_pass }}"
   file_upload_url: "file:///${user.home}/fileserver/"
+  userName: "guest"￼
+  password: "guest"
 application:
   properties:
     basePortalUrl: "https://{{ external_host }}/{{ foia_portal_context }}"


### PR DESCRIPTION
Enable authentication on ActiveMQ, define user and password in the facts file and make use of it between applications.