### PR TITLE
Arkcase log level should be configurable by the installer

### DIFF
--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -484,3 +484,7 @@ email_receiver_consultation_password: ""
 # define username and password for ActiveMQ authentication between apps
 activemq_user: ""
 activemq_password: ""
+
+# define arkcase_log_level core/foia with one of thge following valid values: trace, debug, info, warn, error
+# if not defined default value will be info
+arkcase_log_level: ""

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -578,3 +578,7 @@ activemq_password: ""
 
 # missing fact during vagrant provisioning 
 arkcase_version: ""
+
+# define arkcase_log_level core/foia with one of thge following valid values: trace, debug, info, warn, error
+# if not defined default value will be info
+arkcase_log_level: ""

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -990,6 +990,26 @@
     - regexp: 'filePattern="\$\{sys\:catalina.base\}/logs'
       replace: 'filePattern="{{ root_folder}}/log/arkcase'
 
+- name: replace arkcase core log level if variable defined in facts file
+  become: yes
+  become_user: arkcase
+  ansible.builtin.replace:
+    path: /home/arkcase/.arkcase/acm/log4j2.xml
+    after: '<Logger name="com.armedia" '
+    before: ' additivity="false">'
+    regexp: '^(.+)$'
+    replace: "level=\"{{ arkcase_log_level | default('info', true) }}\""
+
+- name: replace arkcase foia log level if variable defined in facts file
+  become: yes
+  become_user: arkcase
+  ansible.builtin.replace:
+    path: /home/arkcase/.arkcase/acm/log4j2.xml
+    after: '<Logger name="gov.foia" '
+    before: ' additivity="false">'
+    regexp: '^(.+)$'
+    replace: "level=\"{{ arkcase_log_level | default('info', true) }}\""
+
 - name: install any extra artifacts
   include_tasks: extra_artifacts.yml
   loop: "{{ arkcase_extra_artifacts }}"


### PR DESCRIPTION
We should introduce a variable arkcase_log_level with valid values from trace, debug, info, warn, error.
This value should update configuration in /home/arkcase/.arkcase/acm/log4j2.xml.
By default I would like it set to info, if it's not explicitly setup.