### PR TITLE
Add daemon-reload to service tasks

### DIFF
--- a/vagrant/provisioning/roles/activemq/tasks/main.yml
+++ b/vagrant/provisioning/roles/activemq/tasks/main.yml
@@ -301,6 +301,7 @@
 - name: enable ActiveMQ to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: activemq
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -489,6 +489,7 @@
 - name: enable Alfresco to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: alfresco
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/confluent-platform-install/tasks/main.yml
+++ b/vagrant/provisioning/roles/confluent-platform-install/tasks/main.yml
@@ -233,6 +233,7 @@
 - name: Enable Zookeeper to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-zookeeper
     enabled: yes
     masked: no
@@ -242,6 +243,7 @@
 - name: Enable Kafka to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-kafka
     enabled: yes
     masked: no
@@ -251,6 +253,7 @@
 - name: Enable Schema Registry to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-schema-registry
     enabled: yes
     masked: no
@@ -260,6 +263,7 @@
 - name: Enable KSQL to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-ksql
     enabled: yes
     masked: no
@@ -269,6 +273,7 @@
 - name: Enable Control Center to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-control-center
     enabled: yes
     masked: no
@@ -278,6 +283,7 @@
 - name: Enable Kafka Rest to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-kafka-rest
     enabled: yes
     masked: no
@@ -287,6 +293,7 @@
 - name: Enable Kafka Connect to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: confluent-kafka-connect
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/elasticsearch-install/tasks/main.yml
+++ b/vagrant/provisioning/roles/elasticsearch-install/tasks/main.yml
@@ -47,6 +47,7 @@
     - name: enable ElasticSearch to start on boot
       become: yes
       systemd:
+        daemon_reload: true
         name: elasticsearch
         enabled: yes
         masked: no

--- a/vagrant/provisioning/roles/haproxy/tasks/main.yml
+++ b/vagrant/provisioning/roles/haproxy/tasks/main.yml
@@ -474,6 +474,7 @@
 - name: enable and start haproxy
   become: yes
   systemd:
+    daemon_reload: true
     name: haproxy
     enabled: yes
     state: started

--- a/vagrant/provisioning/roles/httpd/tasks/main.yml
+++ b/vagrant/provisioning/roles/httpd/tasks/main.yml
@@ -108,6 +108,7 @@
 - name: enable httpd to run at startup
   become: yes
   systemd:
+    daemon_reload: true
     name: httpd
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/mariadb/tasks/main.yml
+++ b/vagrant/provisioning/roles/mariadb/tasks/main.yml
@@ -155,6 +155,7 @@
 - name: enable MariaDB to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: mariadb
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/mongodb/tasks/main.yml
+++ b/vagrant/provisioning/roles/mongodb/tasks/main.yml
@@ -54,6 +54,7 @@
 - name: enable Mongodb to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: mongod
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
@@ -254,6 +254,7 @@
 - name: enable Pentaho to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: pentaho
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/samba/tasks/main.yml
+++ b/vagrant/provisioning/roles/samba/tasks/main.yml
@@ -147,6 +147,7 @@
 - name: enable Samba to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: samba
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/snowbound/tasks/main.yml
+++ b/vagrant/provisioning/roles/snowbound/tasks/main.yml
@@ -129,6 +129,7 @@
 - name: enable Snowbound to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: snowbound
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/solr/tasks/install-service.yml
+++ b/vagrant/provisioning/roles/solr/tasks/install-service.yml
@@ -86,6 +86,7 @@
 - name: enable Solr to start on boot
   become: yes
   systemd:
+    daemon_reload: true
     name: solr
     enabled: yes
     masked: no

--- a/vagrant/provisioning/roles/start-arkcase/tasks/main.yml
+++ b/vagrant/provisioning/roles/start-arkcase/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: start config server
   become: yes
   systemd:
+    daemon_reload: true
     name: "config-server"
     state: started
 
@@ -19,6 +20,7 @@
 - name: start arkcase
   become: yes
   systemd:
+    daemon_reload: true
     name: "arkcase"
     state: started
 


### PR DESCRIPTION
When we are deleting some of the applications which are deployed through the installer no matter if that’s an update or some maintenance and delete the service from /etc/systemd/system although we did systemctl daemon-reload before we start the installer when the installer come up to that specific role where the system file should be executed to start the service the installer fails. That’s why we decide to go with this approach.