### PR TITLE
Delete alias tomcat from keystore if exists, will be recreated after

### DIFF
--- a/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-configuration/tasks/main.yml
@@ -18,6 +18,12 @@
     - src: "repository.spring.properties"
       dest: "{{ root_folder }}/app/pentaho/pentaho-server/pentaho-solutions/system/repository.spring.properties"
 
+- name: delete alias tomcat from keystore if exists
+  become: yes
+  become_user: pentaho
+  command: keytool -delete -alias tomcat -keystore {{ root_folder }}/app/pentaho/pentaho-server/tomcat/conf/keystore --deststorepass password
+  ignore_errors: true
+
 - name: import arkcase keystore
   become: yes
   become_user: pentaho


### PR DESCRIPTION
Inside the pentaho-configuration main.yml file we are using command module to create the keystore instead of ansible java_cert which make this task to fail if tomcat alias already exist inside the keystore.

That’s why we decide to create another command to delete alias tomcat if already exists, which afterwards will be recreated and if not this task is going to be ignored.