### PR TITLE
Fix an issue where the groupadd fails because of nonescalated privileges

### DIFF
--- a/vagrant/provisioning/roles/activemq/tasks/main.yml
+++ b/vagrant/provisioning/roles/activemq/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure group activemq exists
+  become: yes
   group:
     name: activemq
     state: present

--- a/vagrant/provisioning/roles/alfresco-setup/tasks/alfresco_user_and_folders.yml
+++ b/vagrant/provisioning/roles/alfresco-setup/tasks/alfresco_user_and_folders.yml
@@ -1,4 +1,5 @@
 - name: Ensure group alfresco exists
+  become: yes
   group:
     name: alfresco
     state: present

--- a/vagrant/provisioning/roles/arkcase-prerequisites/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-prerequisites/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure group arkcase exists
+  become: yes
   group:
     name: arkcase
     state: present

--- a/vagrant/provisioning/roles/pentaho-pdi-client/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-pdi-client/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure group pentaho-pdi exists
+  become: yes
   group:
     name: pentaho-pdi
     state: present

--- a/vagrant/provisioning/roles/pentaho-setup/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-setup/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure group pentaho exists
+  become: yes
   group:
     name: pentaho
     state: present

--- a/vagrant/provisioning/roles/snowbound/tasks/main.yml
+++ b/vagrant/provisioning/roles/snowbound/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure group snowbound exists
+  become: yes
   group:
     name: snowbound
     state: present

--- a/vagrant/provisioning/roles/solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/solr/tasks/main.yml
@@ -11,6 +11,7 @@
       - lsof
 
 - name: Ensure group solr exists
+  become: yes
   group:
     name: solr
     state: present


### PR DESCRIPTION
On building the AWS MarketPlace AMI's I am encountering an issue with this.
Hopefully this will resolve the issue