### PR TITLE
Ignore media metadata properties detected by tika

### DIFF
--- a/vagrant/provisioning/roles/solr/files/schema.xml
+++ b/vagrant/provisioning/roles/solr/files/schema.xml
@@ -154,6 +154,7 @@ http://lucene.apache.org/solr/guide/documents-fields-and-schema-design.html
        EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
        RESTRICTION: the glob-like pattern in the name attribute must have a "*" only at the start or the end.  -->
    
+    <dynamicField name="ignored_*" type="ignored" />
     <dynamicField name="*_i"  type="pint"    indexed="true"  stored="true"/>
     <dynamicField name="*_is" type="pints"    indexed="true"  stored="true"/>
     <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />

--- a/vagrant/provisioning/roles/solr/files/solrconfig.xml
+++ b/vagrant/provisioning/roles/solr/files/solrconfig.xml
@@ -801,6 +801,8 @@
       <str name="uprefix">ignored_</str>
       <str name="captureAttr">true</str>
 
+      <str name="fmap.media_white_point">ignored_</str>
+      <str name="fmap.media_black_point">ignored_</str>
       <str name="fmap.meta">ignored_</str>
       <str name="fmap.content">content</str>
       <str name="fmap.a">links</str>


### PR DESCRIPTION
Create new dynamic field with prefix "ignored_" and set type=ignored
Map media_white_point and media_black_point properties detected by tika with the new ignored prefix.

This is known Solr issue, there is a [ticket ](https://issues.apache.org/jira/browse/SOLR-8017)on their Jira and the only way to solve it is to ignore the property detected by Solr-Tika service.

On environments with Solr in standalone mode we should only update those files.
On environments with Solr in cloud mode, we should update those files and register them on zookeeper.

./zkcli.sh -cmd upconfig -zkhost 127.0.0.1:2181 -confname arkcaseConfig -confdir /path to the folder with the config files.
