### PR TITLE
DSO-485 Match ansible hosts automatically

### DIFF
--- a/vagrant/provisioning/arkcase-all.yml
+++ b/vagrant/provisioning/arkcase-all.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: all, localhost
   roles:
     - role: common
       tags: [core, common, upgrade, marketplace]


### PR DESCRIPTION
When starting ansible on localhost we should change hosts: all to localhost this PR fix that and no need to do that manually. Tested locally and ansible can operate. We need to test this on AWX Tower