### PR TITLE
Fix for CVE-2021-44228

### DIFF
--- a/vagrant/provisioning/roles/solr/tasks/install-service.yml
+++ b/vagrant/provisioning/roles/solr/tasks/install-service.yml
@@ -35,7 +35,7 @@
     insertbefore: EOF
     marker: "# {mark} ANSIBLE MANAGED BLOCK - JMX"
     block: |
-      SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=true -Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.port=50502 -Dcom.sun.management.jmxremote.rmi.port=50503 -Dcom.sun.management.jmxremote.access.file={{ root_folder }}/app/solr/access.file -Dcom.sun.management.jmxremote.password.file={{ root_folder }}/app/solr/password.file -Djava.rmi.server.hostname={{ internal_host }}"
+      SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=true -Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.port=50502 -Dcom.sun.management.jmxremote.rmi.port=50503 -Dcom.sun.management.jmxremote.access.file={{ root_folder }}/app/solr/access.file -Dcom.sun.management.jmxremote.password.file={{ root_folder }}/app/solr/password.file -Djava.rmi.server.hostname={{ internal_host }} -Dlog4j.formatMsgNoLookups=true"
   when: solr_jmx_enabled|bool
 
 - name: update environment file - TLS

--- a/vagrant/provisioning/roles/tomcat/tasks/main.yml
+++ b/vagrant/provisioning/roles/tomcat/tasks/main.yml
@@ -167,7 +167,7 @@
         insertbefore: EOF
         marker: "# {mark} ANSIBLE MANAGED BLOCK - JAVA_OPTS"
         block: |
-          export JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStorePassword={{ java_trust_store_pass }} -Djavax.net.ssl.trustStore={{ java_trust_store }}"
+          export JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStorePassword={{ java_trust_store_pass }} -Djavax.net.ssl.trustStore={{ java_trust_store }} -Dlog4j.formatMsgNoLookups=true"
     - name: set CATALINA_OPTS
       become: yes
       become_user: "{{ tc.user }}"


### PR DESCRIPTION
We have added the fix for the installer for previous versions of ArkCase where we don't have the Apache Log4j updated version that is not vulnerable to this vulnerability