### PR TITLE
Added my own version of the backup roles

### DIFF
--- a/vagrant/provisioning/roles/backup_data/tasks/main.yml
+++ b/vagrant/provisioning/roles/backup_data/tasks/main.yml
@@ -1,0 +1,80 @@
+- name: Set some base variables
+  set_fact:
+   src_dir: "{{ root_folder }}"
+   tgt_dir: "{{ root_folder }}/backups-{{ ansible_date_time.iso8601 }}"
+
+- name: ensure Solr is stopped
+  become: yes
+  systemd:
+    name: solr
+    state: stopped
+
+- name: ensure Alfresco is stopped
+  become: yes
+  systemd:
+    name: alfresco
+    state: stopped
+
+- name: ensure Snowbound is stopped
+  become: yes
+  systemd:
+    name: snowbound
+    state: stopped    
+    
+- name: backup data folders 
+  become: yes
+  file:
+    path: "{{ tgt_dir }}/data"
+    state: present
+
+- name: Solr data backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/data/solr"
+    dest: "{{ tgt_dir }}/data/solr"
+    directory_mode: yes
+    owner: solr
+    group: solr
+    backup: yes
+
+- name: Alfresco data backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/data/alfresco"
+    dest: "{{ tgt_dir }}/data/alfresco"
+    directory_mode: yes
+    owner: alfresco
+    group: alfresco
+    backup: yes
+
+- name: Snowbound docs backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/data/snowbound/snowbound-docs"
+    dest: "{{ tgt_dir }}/data/snowbound/snowbound-docs"
+    directory_mode: yes
+    owner: snowbound
+    group: snowbound
+    backup: yes
+
+- name: External-portal-api files backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/data/arkcase-home/.external-portal-api/files"
+    dest: "{{ tgt_dir }}/data/arkcase-home/.external-portal-api-files"
+    directory_mode: yes
+    owner: arkcase
+    group: arkcase
+    backup: yes
+  when: foia_portal_context is defined
+
+- name: External-portal http context backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/data/httpd/htdocs/foia"
+    dest: "{{ tgt_dir }}/data/httpd/htdocs/foia"
+    directory_mode: yes
+    owner: arkcase
+    group: arkcase
+    backup: yes
+  when: foia_portal_context is defined

--- a/vagrant/provisioning/roles/backup_db/tasks/main.yml
+++ b/vagrant/provisioning/roles/backup_db/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Set some base variables
+  set_fact:
+   src_dir: "{{ root_folder }}"
+   tgt_dir: "{{ root_folder }}/backups-{{ ansible_date_time.iso8601 }}"
+
+- name: ensure ArkCase is stopped
+  become: yes
+  systemd:
+    name: arkcase
+    state: stopped
+
+- name: ensure Alfresco is stopped
+  become: yes
+  systemd:
+    name: alfresco
+    state: stopped
+    
+- name: backup db folders 
+  become: yes
+  file:
+    path: "{{ tgt_dir }}/db"
+    state: directory
+
+- name: ArkCase db backup
+  become: yes
+  mysql_db:
+    state: dump
+    name: arkcase
+    target: "{{ tgt_dir }}/db/arkcase.sql"
+    login_user: "{{ database_arkcase_user }}"
+    login_pass: "{{ default_database_password }}"
+    login_host: "{{ database_host }}"
+    ca_cert: "{{ ssl_ca }}"
+
+- name: Alfresco db backup
+  become: yes
+  mysql_db:
+    state: dump
+    name: alfresco
+    target: "{{ tgt_dir }}/db/alfresco.sql"
+    login_user: alfresco
+    login_pass: "{{ default_database_password }}"
+    login_host: "{{ database_host }}"
+    ca_cert: "{{ ssl_ca }}"

--- a/vagrant/provisioning/roles/backup_jar_war/tasks/main.yml
+++ b/vagrant/provisioning/roles/backup_jar_war/tasks/main.yml
@@ -1,0 +1,60 @@
+- name: Set some base variables
+  set_fact:
+   src_dir: "{{ root_folder }}"
+   tgt_dir: "{{ root_folder }}/backups-{{ ansible_date_time.iso8601 }}"
+
+- name: ensure Config-Server is stopped
+  become: yes
+  systemd:
+    name: config-server
+    state: stopped
+
+- name: ensure Snowbound is stopped
+  become: yes
+  systemd:
+    name: snowbound
+    state: stopped    
+
+- name: ensure External Portal is stopped
+  become: yes
+  systemd:
+    name: arkcase
+    state: stopped
+  when: foia_portal_context is defined
+
+- name: backup data folders 
+  become: yes
+  file:
+    path: "{{ tgt_dir }}/webapps"
+    state: present
+
+- name: Config-Server jar backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/app/config-server"
+    dest: "{{ tgt_dir }}/app/config-server"
+    directory_mode: yes
+    owner: arkcase
+    group: arkcase
+    backup: yes
+
+- name: Snowbound war backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/app/snowbound/webapps/VirtualViewerJavaHTML5.war"
+    dest: "{{ tgt_dir }}/app/snowbound/webapps"
+    directory_mode: yes
+    owner: snowbound
+    group: snowbound
+    backup: yes
+
+- name: External-portal-api war backup
+  become: yes
+  copy:
+    src:  "{{ src_dir }}/app/arkcase/webapps/arkcase#external-portal.war"
+    dest: "{{ tgt_dir }}/app/arkcase/webapps"
+    directory_mode: yes
+    owner: arkcase
+    group: arkcase
+    backup: yes
+  when: foia_portal_context is defined


### PR DESCRIPTION
They differ in the following ways:

- Mirror the source directory structures where possible/feasible
- Use centrally-defined variables (facts) where possible so as to minimize the chance of mistakes later on (can facts be redefined? Is this the right way to do it?)
- Try to keep things as self-contained as possible so it's easy to harvest the backup
- TODO: add archival of the freshly-created backup and removal of the temporary working directory

More work is pending to support PostgreSQL, and other DBs for backups, reliably locate and backup .arkcase, etc.