### PR TITLE
Fix: Run npm install husky with sudo privileges

### DIFF
--- a/vagrant/provisioning/roles/arkcase-prerequisites/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-prerequisites/tasks/main.yml
@@ -73,11 +73,12 @@
       - nodejs
 
 - name: install the npm module 'husky' which seems required by some ArkCase versions
+  become: yes
   npm:
     name: husky
     global: yes
     state: present
-    
+
 - include_tasks: "{{ role_path }}/../tomcat/tasks/main.yml"
   args:
     apply:


### PR DESCRIPTION
While building the AWS AMI's encounter this issue where the npm command should be run with sudo privileges.