### PR TITLE
Fix: AWS AMI Startup script cannot contact ldap server

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -97,7 +97,7 @@
     line: "{{ item }}"
   loop:
     - "{{ arkcase_host_address | default('127.0.0.1') }} arkcase-host"
-    - "{{ ansible_default_ipv4.address }} {{ internal_host }}"
+    - "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }} {{ internal_host }}"
   # Don't try to modify the `/etc/hosts` file when running inside
   # Docker, this is not possible. Instead, use `--add-host` on the
   # `docker run` command line.


### PR DESCRIPTION
During the execution of the startup script runs into error: Cannot contact ldap server.
Missing name reference to ip in the hosts file.