### PR TITLE
Fix: Restored deletion of localhost to point to internal host, since …

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -98,6 +98,7 @@
   loop:
     - "{{ arkcase_host_address | default('127.0.0.1') }} arkcase-host"
     - "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }} {{ internal_host }}"
+    - "127.0.0.1 {{ internal_host }}"
   # Don't try to modify the `/etc/hosts` file when running inside
   # Docker, this is not possible. Instead, use `--add-host` on the
   # `docker run` command line.


### PR DESCRIPTION
…AWS AMI gets wrong IP during the building process