### PR TITLE
Switching the order of hosts file entries

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -97,8 +97,8 @@
     line: "{{ item }}"
   loop:
     - "{{ arkcase_host_address | default('127.0.0.1') }} arkcase-host"
-    - "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }} {{ internal_host }}"
     - "127.0.0.1 {{ internal_host }}"
+    - "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }} {{ internal_host }}"
   # Don't try to modify the `/etc/hosts` file when running inside
   # Docker, this is not possible. Instead, use `--add-host` on the
   # `docker run` command line.


### PR DESCRIPTION
Currently, we are required to do a haproxy restart (the end user should do this restart) if we like to avoid the solr issue. Let's try if this will work for both AWS and Vagrant as a solution