### PR TITLE
DSO-545 Comment Elasticsearch role in the developers playbook

### DIFF
--- a/vagrant/provisioning/arkcase-dev.yml
+++ b/vagrant/provisioning/arkcase-dev.yml
@@ -47,8 +47,8 @@
       tags: [core, snowbound, snowbound-app]
     - role: confluent-platform-install
       tags: [confluent]
-    - role: elasticsearch-install
-      tags: [elasticsearch]
+    # - role: elasticsearch-install
+    #   tags: [elasticsearch]
     - role: microservices
       tags: [microservices]
     - role: tesseract


### PR DESCRIPTION
We decide to remove Elasticsearch from the playbook because it is not implemented with any service in the stack and it uses quite a lot resources from the developers VM.

Once we decide to use Elasticsearch again we can easily bring it back to be installed.
