### PR TITLE
DSO-546 Skip remove-solr role if solr is already in cloud mode

### DIFF
--- a/vagrant/provisioning/roles/remove-solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/remove-solr/tasks/main.yml
@@ -1,3 +1,15 @@
+# get solr mode it's either std - standalone or solrcloud
+- name: get solr mode
+  become: yes
+  uri:
+    validate_certs: no
+    url: https://{{ solr_host }}:8983/solr/admin/info/system?wt=json
+    return_content: yes
+  register: current_solr_mode
+
+- set_fact:
+    solr_mode: "{{ current_solr_mode | json_query('json.mode') }}"
+
 - name: Check systemd solr file exists
   stat:
     path: /etc/systemd/system/solr.service
@@ -8,7 +20,7 @@
   systemd:
     name: solr
     state: stopped
-  when: service_file.stat.exists
+  when: service_file.stat.exists and solr_mode == "std"
 
 - name: Remove solr config files and folders
   become: yes
@@ -22,3 +34,4 @@
     - "{{ root_folder }}/app/solr"
     - "{{ root_folder }}/install/solr"
     - "/etc/systemd/system/solr.service"
+  when: solr_mode == "std"


### PR DESCRIPTION
In case the installer goes through remove-solr and solr role and fails afterwards or it the needs to be rerun for some reason while solr is in solrcloud mode we don't need to execute remove-solr role.