### PR TITLE
ACS-467 Installer deploy fails, failed to import python packages

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -56,6 +56,8 @@
       - sshpass
       - python3
       - python3-pip
+      - python-setuptools
+      - python-cryptography
 
 - name: copy requirements.txt needed for pip2 upgrade
   become: yes


### PR DESCRIPTION
We had a recent deployments on our AI4 env. and our Ovirt env. failing with the message failed to import python library setuptools and cryptography. 
Now these python libraries are added to the installer.