### PR TITLE
ACS-506 Create a script that will start inactive services on VM boot

### DIFF
--- a/vagrant/provisioning/roles/arkcase-developer/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-developer/tasks/main.yml
@@ -4,3 +4,18 @@
     apply:
       vars:
         item: arkcase
+
+- name: transfer start services script
+  become: yes
+  template:
+    src: "start_services.sh"
+    dest: /bin/start_services.sh
+    mode: "+x"
+
+- name: run CRON job to invoke the script after VM boot
+  become: yes
+  become_method: sudo
+  cron:
+    name: "start services that are required for ArkCase to work"
+    special_time: reboot
+    job: "/bin/start_services.sh"

--- a/vagrant/provisioning/roles/arkcase-developer/tasks/templates/start_services.sh
+++ b/vagrant/provisioning/roles/arkcase-developer/tasks/templates/start_services.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##this script will check all of the components that are required for ArkCase to work on developer VM
+##if the services are not running it will start the services
+
+##list the services to check
+SERVICES=('haproxy' 'config-server' 'mariadb' 'httpd' 'pentaho' 'snowbound' 'solr' 'alfresco' 'activemq' 'confluent-kafka' 'confluent-zookeeper' 'confluent-control-center' 'confluent-kafka-connect' 'confluent-kafka-rest' 'confluent-ksql' 'confluent-kafka-connect' 'confluent-schema-registry' 'mongod' 'samba')
+
+ for i in "${SERVICES[@]}"
+  do
+    echo $i
+
+    systemctl is-active $i
+    STATS=$(echo $?)
+
+    systemctl list-unit-files --all | grep $i
+    ISSERVICE=$(echo $?)
+
+    ###If service is not running and is inactive####
+    if [[ $STATS -ne "0" ]] && [[ $ISSERVICE -eq '' ]]
+        then
+        ##TRY TO RESTART THE SERVICE###
+        systemctl start $i
+    fi
+  done


### PR DESCRIPTION
We need a shell script that will run on boot of the developers VM and start the inactive services since developers have encountered many times inactive services after booting the VM and they have to SSH into the VM and start the services manually, which many of them are not aware of whats going under the hood and call support.