### PR TITLE
ACS-508 Fix for solr log4j vulnerabilities

### DIFF
--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -516,4 +516,4 @@ arkcase_vault_authMethod: ""
 arkcase_vault_username: ""
 arkcase_vault_password: ""
 
-log4j_version: ""
+solr_log4j_version: ""

--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -515,3 +515,5 @@ arkcase_vault_appRole: ""
 arkcase_vault_authMethod: ""
 arkcase_vault_username: ""
 arkcase_vault_password: ""
+
+log4j_version: ""

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -612,3 +612,5 @@ arkcase_vault_appRole: ""
 arkcase_vault_authMethod: ""
 arkcase_vault_username: ""
 arkcase_vault_password: ""
+
+solr_log4j_version: ""

--- a/vagrant/provisioning/roles/solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/solr/tasks/main.yml
@@ -98,3 +98,83 @@
 - name: Expose required ports for solr
   include_tasks: firewall.yml
   when: enable_firewall is undefined or enable_firewall
+
+- name: find prometheus-exporter log4j jars that are vulnerable
+  find:
+    paths: "{{ root_folder }}/app/solr/contrib/prometheus-exporter/lib"
+    patterns: "log4j*"
+  register: log4j_prom_exp
+
+- name: remove prometheus-exporter vulnerable log4j jars
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ log4j_prom_exp.files }}"
+
+- name: find solr server log4j jars that are vulnerable
+  find:
+    paths: "{{ root_folder }}/app/solr/server/lib/ext"
+    patterns: "log4j*"
+  register: log4j_srv_jar
+
+- name: remove solr server vulnerable log4j jars
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ log4j_srv_jar.files }}"
+
+- name: download and install log4j-api jar
+  get_url:
+    url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/{{ solr_log4j_version | default('2.17.1', true) }}/log4j-api-{{ solr_log4j_version | default('2.17.1', true) }}.jar
+    dest: "{{ item }}"
+    owner: 'solr'
+    group: 'solr'
+    mode: '0644'
+  with_items:
+    - "{{ root_folder }}/app/solr/contrib/prometheus-exporter/lib/log4j-api-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+    - "{{ root_folder }}/app/solr/server/lib/ext/log4j-api-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+
+- name: download and install log4j-core jar
+  get_url:
+    url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/{{ solr_log4j_version | default ('2.17.1', true) }}/log4j-core-{{ solr_log4j_version | default ('2.17.1', true) }}.jar
+    dest: "{{ item }}"
+    owner: 'solr'
+    group: 'solr'
+    mode: '0644'
+  with_items:
+    - "{{ root_folder }}/app/solr/contrib/prometheus-exporter/lib/log4j-core-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+    - "{{ root_folder }}/app/solr/server/lib/ext/log4j-core-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+
+- name: download and install log4j-slf4j-impl jar
+  get_url:
+    url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/{{ solr_log4j_version | default ('2.17.1', true) }}/log4j-slf4j-impl-{{ solr_log4j_version | default ('2.17.1', true) }}.jar
+    dest: "{{ item }}"
+    owner: 'solr'
+    group: 'solr'
+    mode: '0644'
+  with_items:
+      - "{{ root_folder }}/app/solr/contrib/prometheus-exporter/lib/log4j-slf4j-impl-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+      - "{{ root_folder }}/app/solr/server/lib/ext/log4j-slf4j-impl-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+
+- name: download and install log4j-1.2-api jar
+  get_url:
+    url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/{{ solr_log4j_version | default ('2.17.1', true) }}/log4j-1.2-api-{{ solr_log4j_version | default ('2.17.1', true) }}.jar
+    dest: "{{ root_folder }}/app/solr/server/lib/ext/log4j-1.2-api-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+    owner: 'solr'
+    group: 'solr'
+    mode: '0644'
+
+- name: download and install log4j-web jar
+  get_url:
+    url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-web/{{ solr_log4j_version | default ('2.17.1', true) }}/log4j-web-{{ solr_log4j_version | default ('2.17.1', true) }}.jar
+    dest: "{{ root_folder }}/app/solr/server/lib/ext/log4j-web-{{ solr_log4j_version | default ('2.17.1', true) }}.jar"
+    owner: 'solr'
+    group: 'solr'
+    mode: '0644'
+  when: solr_version is version('8.8.2', '>=')
+
+- name: restart solr
+  become: yes
+  systemd:
+    name: solr
+    state: restarted


### PR DESCRIPTION
solr prometheus-exporter and solr server are using vulnerable log4j libraries, which needs to be changed with the latest patched.
