### PR TITLE
ACS-456 use default for alfresco password

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -38,7 +38,7 @@
       - name: default_user
         value: "{{ default_user_password }}"
       - name: alfresco_admin_password
-        value: "{{ alfresco_admin_password }}"
+        value: "{{ alfresco_admin_password | default('admin') }}"
       - name: old_default_user
         value: AcMd3v$
       - name: activemq_password


### PR DESCRIPTION
For AWX templates with older facts, where the facts don't specify the password.