### PR TITLE
Add support for Alfresco6 in the installer

### DIFF
--- a/vagrant/provisioning/arkcase-all.yml
+++ b/vagrant/provisioning/arkcase-all.yml
@@ -39,6 +39,14 @@
       tags: [core, activemq, marketplace]
     - role: alfresco-search-services
       tags: [alfresco-search-services]
+    - role: alfresco-setup
+      tags: [alfresco6]
+    - role: alfresco-ce
+      tags: [alfresco6]
+    - role: alfresco
+      tags: [alfresco6]
+    - role: alfresco-site
+      tags: [alfresco6]
     - role: alfresco7-setup
       tags: [core, alfresco, alfresco-setup, marketplace]
     - role: alfresco7-ce


### PR DESCRIPTION
This is a change needed to support Alfresco 6 because currently we have preprod environments that have alfresco 6 and we need to be able to install the same on the production environments. 

Note: Let's ask QA to first do a thorough test of Alfresco 7 integration with ArkCase before we proceed with Alfresco 7 as default method of installation.