### PR TITLE
ACS-457 Add activemq username and password in alfresco-global.properties

### DIFF
--- a/vagrant/provisioning/roles/alfresco7/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco7/tasks/main.yml
@@ -271,6 +271,8 @@
       local.transform.service.enabled=false
       dir.keystore={{ root_folder }}/app/alfresco7/shared/classes/alfresco/extension/keystore
       messaging.broker.url=ssl://{{ activemq_host }}:61616
+      messaging.broker.username={{ activemq_user | default('guest', true) }}
+      messaging.broker.password={{ activemq_password | default('guest', true) }}
       index.subsystem.name=solr6
       solr.secureComms=none
       solr.host={{ internal_host }}


### PR DESCRIPTION
Add activemq credentials in alfresco-global.properties. 
*Note: how this change will affect something? I honestly don't know if this changes anything. Without it, it is working fine. With this changes, it is working same. What is the outcome that we want here? Please elaborate someone if it is familiar with this issue..