### PR TITLE
Change the execution position for minio

### DIFF
--- a/vagrant/provisioning/arkcase-all.yml
+++ b/vagrant/provisioning/arkcase-all.yml
@@ -1,9 +1,6 @@
 ---
 - hosts: all
   roles:
-    - role: minio
-      tags: [microservices, minio]
-      when: enable_minio | default(false)
     - role: common
       tags: [core, common, upgrade, marketplace]
     - role: arkcase-pre-upgrade
@@ -90,6 +87,9 @@
       tags: [microservices, elasticsearch]
     - role: microservices
       tags: [microservices]
+    - role: minio
+      tags: [microservices, minio]
+      when: enable_minio | default(false)
     - role: pentaho-license
       tags: [pentaho-license, pentaho-ee, arkcase-ee]   
     - role: arkcase-prerequisites

--- a/vagrant/provisioning/arkcase-ce.yml
+++ b/vagrant/provisioning/arkcase-ce.yml
@@ -1,8 +1,6 @@
 ---
 - hosts: localhost
   roles:
-    - role: minio
-      tags: [microservices, minio]
     - role: common
       tags: [core, common]
     - role: pki-aws-csr
@@ -66,6 +64,8 @@
       tags: [core, snowbound, snowbound-app]
     - role: confluent-platform-install
       tags: [confluent]
+    - role: minio
+      tags: [microservices, minio]
     - role: arkcase-prerequisites
       tags: [core, arkcase]
     - role: arkcase-app

--- a/vagrant/provisioning/arkcase-dev.yml
+++ b/vagrant/provisioning/arkcase-dev.yml
@@ -1,8 +1,6 @@
 ---
 - hosts: localhost
   roles: 
-    - role: minio
-      tags: [microservices, minio]
     - role: common
       tags: [core, common]
     - role: pki-dev
@@ -65,6 +63,8 @@
     #   tags: [elasticsearch]
     - role: microservices
       tags: [microservices]
+    - role: minio
+      tags: [microservices, minio]
     - role: tesseract
       tags: [core, arkcase, tesseract]
     - role: firewall


### PR DESCRIPTION
Currently when the developers were provisioning the vagrant box the installer would fail because the tools (wget) used to install minio that we are installing in the common role were not installed on the base CentOS 7 image.