### PR TITLE
Extracted the hard-coded timezone value into a fact

### DIFF
--- a/vagrant/provisioning/roles/common/tasks/main.yml
+++ b/vagrant/provisioning/roles/common/tasks/main.yml
@@ -133,7 +133,7 @@
 - name: set timezone to UTC
   become: yes
   timezone:
-    name: UTC
+    name: "{{ time_zone | default('UTC') }}"
 
 - name: Set default locale to en_US.utf8
   become: yes


### PR DESCRIPTION
When we do our deployments on various customers we cannot always presume that the time zone they are in matches UTC so I removed the time zone into a time_zone variable and added a default value in case it's not defined in the facts.