### PR TITLE
Changing the installation location of rpm for Libre Office

### DIFF
--- a/vagrant/provisioning/roles/arkcase-file-utils/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-file-utils/tasks/main.yml
@@ -65,7 +65,7 @@
 - name: Check Libreoffice Installation
   become: yes
   stat:
-    path: "/opt/libreoffice7.3/program/soffice"
+    path: "/opt/app/arkcase/app/program/soffice"
   register: libreoffice_bin_exists
 
 - include_tasks: "{{ role_path }}/../common/tasks/download.yml"
@@ -84,10 +84,16 @@
     dest: /tmp/
   when: not libreoffice_bin_exists.stat.exists
 
+- name: Ensure that libreoffice7.3-freedesktop-menus-7.3.5-2.noarch.rpm is removed
+  become: yes
+  command:
+    cmd: rm /tmp/LibreOffice_7.3.5.2_Linux_x86-64_rpm/RPMS/libreoffice7.3-freedesktop-menus-7.3.5-2.noarch.rpm
+  when: not libreoffice_bin_exists.stat.exists
+
 - name: install LibreOffice
   become: yes
   command:
-    cmd: rpm -Uvih /tmp/LibreOffice*/RPMS/*.rpm
+    cmd: rpm -Uvih --prefix=/opt/app/arkcase/app /tmp/LibreOffice*/RPMS/*.rpm
     warn: false
   when: not libreoffice_bin_exists.stat.exists
 

--- a/vagrant/provisioning/roles/arkcase-file-utils/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-file-utils/tasks/main.yml
@@ -87,13 +87,13 @@
 - name: Ensure that libreoffice7.3-freedesktop-menus-7.3.5-2.noarch.rpm is removed
   become: yes
   command:
-    cmd: rm /tmp/LibreOffice_7.3.5.2_Linux_x86-64_rpm/RPMS/libreoffice7.3-freedesktop-menus-7.3.5-2.noarch.rpm
+    cmd: rm /tmp/LibreOffice_{{ libre_office_version | (default('7.3.5.2') }}_Linux_x86-64_rpm/RPMS/libreoffice7.3-freedesktop-menus-{{ libre_office_version | (default('7.3.5-2') }}.noarch.rpm
   when: not libreoffice_bin_exists.stat.exists
 
 - name: install LibreOffice
   become: yes
   command:
-    cmd: rpm -Uvih --prefix=/opt/app/arkcase/app /tmp/LibreOffice*/RPMS/*.rpm
+    cmd: rpm -Uvih --prefix=/opt/app/arkcase/app/libreoffice /tmp/LibreOffice*/RPMS/*.rpm
     warn: false
   when: not libreoffice_bin_exists.stat.exists
 


### PR DESCRIPTION
As per https://arkcase.atlassian.net/browse/DSO-660 we have changed the location where the rpm's are extracted.
NOTE: one of the rpm's named libreoffice7.3-freedesktop-menus-7.3.5-2.noarch.rpm is NOT relocatable which means it cannot be installed under a different directory except /opt but I believe that this is an rpm that we don't need. If you believe that we need this rpm then let's think of another solution if not let's merge it like this.