### PR TITLE
ACFP-2691 Link the Cognito config to an LDAP directory

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/templates/arkcase-cognito.yaml
+++ b/vagrant/provisioning/roles/arkcase-app/templates/arkcase-cognito.yaml
@@ -2,6 +2,7 @@ cognito-core:
   accessKey: {{ cognito_core_access_key }}
   secretKey: {{ cognito_core_secret_key }}
   userPool: {{ cognito_core_user_pool }}
+  ldapDirectoryName: "{{ ldap_user_domain | replace('.', '_') }}"
   clientId: {{ cognito_core_client_id }}
   clientSecret: {{ cognito_core_client_secret }}
   loginUri: {{ cognito_core_login_url }}


### PR DESCRIPTION
After Cognito authentication we have to lookup the user in our acm_user table.  To differentiate between portal and ArkCase users, we need this directory bean name in the Cognito configuration, so we know which directory to query.