### PR TITLE
DSO-747 Add recursively to the restorecon command

### DIFF
--- a/vagrant/provisioning/roles/haproxy/tasks/main.yml
+++ b/vagrant/provisioning/roles/haproxy/tasks/main.yml
@@ -77,7 +77,7 @@
 
 - name: Apply new SELinux file context to filesystem
   become: yes
-  command: restorecon -v {{ root_folder }}/log/haproxy
+  command: restorecon -R -v {{ root_folder }}/log/haproxy
   when: allow_haproxy_logging is changed
 
 - name: Copy haproxy log configuration into rsyslog.d


### PR DESCRIPTION
Since the issue only happened to PRC, this will be OK for new installations. Or, we want every install to be sometimes run with haproxy tag in order to change the SELinux file context mapping to something new, like var_log_t from the ticket description?