### PR TITLE
Remove the new ignore_errors attributes

### DIFF
--- a/vagrant/provisioning/roles/alfresco-site/tasks/create-site.yml
+++ b/vagrant/provisioning/roles/alfresco-site/tasks/create-site.yml
@@ -1,6 +1,5 @@
 - name: create {{ item.s_name }} share site
   command: curl -k -sS --user admin:"{{ alfresco_admin_password }}" -H 'Content-Type{{ ":" }} application/json' -H 'Accept{{ ":" }} */*' -H 'Alfresco-CSRFToken{{ ":" }} {{ csrftoken }}' --cookie cookie.txt --cookie-jar cookie.txt -X POST '{{ alfresco_url }}/share/service/modules/create-site' --data '{ "title"{{ ":" }} "{{ item.s_title }}","shortName"{{ ":" }} "{{ item.s_name }}","description"{{ ":" }} "{{ item.s_description }}","sitePreset"{{ ":" }} "{{ item.s_preset }}", "type"{{ ":" }} "{{ item.s_type }}","visibility"{{ ":" }} "PUBLIC","compliance"{{ ":" }} "{{ item.s_compliance }}" }' --compressed
-  ignore_errors: true
   register: acm_site_out
   failed_when: '"true" not in acm_site_out.stdout and "error.duplicateShortName" not in acm_site_out.stdout'
   changed_when: '"Success" in acm_site_out.stdout'

--- a/vagrant/provisioning/roles/alfresco-site/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco-site/tasks/main.yml
@@ -25,7 +25,6 @@
 # note, can't use get_uri here since we need to keep the cookie jar
 - name: login to Share
   command: curl -k -sS --user admin:"{{ alfresco_admin_password }}" --cookie cookie.txt --cookie-jar cookie.txt -H "Content-Type:application/x-www-form-urlencoded" --data "success=/share/page/" --data "failure=/share/page/?error=true" --data "username=admin" --data password="{{ alfresco_admin_password }}" -X POST "{{ alfresco_url }}/share/page/dologin"
-  ignore_errors: true
   changed_when: false
 
 - name: check if login succeeded
@@ -36,7 +35,6 @@
 
 - name: get the CSRFToken
   command: curl -k -sS --user admin:"{{ alfresco_admin_password }}" --cookie cookie.txt --cookie-jar cookie.txt "{{ alfresco_url }}/share/service/modules/authenticated?a=user"
-  ignore_errors: true
   changed_when: false
 
 - name: check if we got the CSRFToken

--- a/vagrant/provisioning/roles/alfresco/tasks/main.yml
+++ b/vagrant/provisioning/roles/alfresco/tasks/main.yml
@@ -47,7 +47,6 @@
     - name: install libreoffice
       become: yes
       shell: yum -y install {{ root_folder }}/install/alfresco/LibreOffice_5.4.6.2_Linux_x86-64_rpm/RPMS/*.rpm
-      ignore_errors: true
   when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "8"
       
 - name: record Alfresco https port, so as to fix the share-config-custom.xml later

--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -376,7 +376,6 @@
   args:
     chdir: "{{ root_folder }}/install/arkcase"
   register: search_service_jar
-  ignore_errors: true
 
 - name: list files in search service jar
   become: yes
@@ -386,7 +385,6 @@
     chdir: "{{ root_folder }}/install/arkcase/WEB-INF/lib"
   register: search_service_contents
   changed_when: false
-  ignore_errors: true
 
 - name: remove tls_defalt_conf from search service jar
   become: yes
@@ -396,7 +394,6 @@
     chdir: "{{ root_folder }}/install/arkcase/WEB-INF/lib"
   when: search_service_jar is changed and 'tls-default.conf' in search_service_contents.stdout
   register: tls_default_removed_from_service
-  ignore_errors: true
 
 - name: update arkcase.war with updated search service jar
   become: yes
@@ -405,7 +402,6 @@
   args:
     chdir: "{{ root_folder }}/install/arkcase"
   when: tls_default_removed_from_service is changed
-  ignore_errors: true
 
 - name: application.yaml file
   become: yes

--- a/vagrant/provisioning/roles/arkcase-file-utils/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-file-utils/tasks/main.yml
@@ -52,7 +52,6 @@
   become: yes
   command:
     cmd: rpm -Uvih /tmp/en-US/RPMS/*.rpm
-  ignore_errors: true
   when: open_office_latest_version is not defined or not open_office_latest_version
 
 - name: remove tmp files
@@ -96,7 +95,6 @@
   become: yes
   command:
     cmd: rpm -Uvih --prefix={{ libreoffice_install_path }} /tmp/LibreOffice*/RPMS/*.rpm
-  ignore_errors: true
   when: not libreoffice_bin_exists.stat.exists
   register: libreoffice_install
   # 41 means the packages were already installed

--- a/vagrant/provisioning/roles/arkcase-interactive-reports/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-interactive-reports/tasks/main.yml
@@ -3,7 +3,6 @@
   become_user: pentaho
   command: 
     cmd: 'wget --no-check-certificate -O {{ root_folder }}/install/pentaho/datasources-list.json --user={{ arkcase_admin_user }} --password "{{ arkcase_admin_password }}" https://{{ internal_host }}:2002/pentaho/plugin/data-access/api/datasource/jdbc/connection'
-  ignore_errors: true
   changed_when: false
 
 - name: read the list of data sources
@@ -25,14 +24,12 @@
 - name: create the ArkCase JDBC data source for interactive reports
   command: 
     cmd: 'wget --no-check-certificate --user={{ arkcase_admin_user }} --password "{{ arkcase_admin_password }}" --post-file {{ root_folder }}/install/pentaho/put_connection.json --header="Content-Type: application/json" https://{{ internal_host }}:2002/pentaho/plugin/data-access/api/connection/add'
-  ignore_errors: true
   register: create_datasource_rest_call
   when: not '"MariaDB Local"' in data_source_list.stdout
 
 - name: Check if keep alive report exists
   command: 
     cmd: 'curl -k -v -u {{ arkcase_admin_user }}:{{ arkcase_admin_password }} https://{{ external_host }}/pentaho/api/scheduler/getJobs'
-  ignore_errors: true
   register: scheduledJobs_out
 
 - name: Copy keep alive files to /tmp
@@ -54,7 +51,6 @@
 - name: Schedule execution of keep alive report on every 30 min to keep connection alive
   command:
     cmd: 'curl -k -v -H "Content-Type: application/xml" --data @/tmp/DBKeepAliveJob.xml -X POST -u {{ arkcase_admin_user }}:{{ arkcase_admin_password }} https://{{ external_host }}/pentaho/api/scheduler/job'
-  ignore_errors: true
   when: '"KeepAliveJob" not in scheduledJobs_out.stdout'
 
 - name: download configuration (if using sftp, and no extension is configured)
@@ -165,5 +161,4 @@
 - name: Install static reports from configuration
   command:
     cmd: 'curl -k -v -X PUT --data-binary "@{{ item.path }}" -u {{ arkcase_admin_user }}:{{ arkcase_admin_password }} https://{{ external_host }}/pentaho/api/repo/files/:public:{{ item.path | dirname | regex_replace(".*\/", "") }}:{{ item.path | basename | replace(" ","%20")}}'
-  ignore_errors: true
   with_items: "{{ static_reports.files }}"

--- a/vagrant/provisioning/roles/common/tasks/download.yml
+++ b/vagrant/provisioning/roles/common/tasks/download.yml
@@ -2,15 +2,11 @@
   stat:
     path: "{{ item.dest }}" 
   register: already_downloaded
+
 - name: download {{ item.name }} if needed (no checksum)
   become: yes
   become_user: "{{ item.owner }}"
   command: wget --read-timeout=1200 {{ item.url }} -O {{ item.dest }}
-  ignore_errors: true
-#  get_url:
-#    timeout: 1200 # default value is too short for Pentaho Server download
-#    url: "{{ item.url }}"
-#    dest: "{{ item.dest }}"
   when: already_downloaded.stat.exists == False
   register: item_downloaded
 
@@ -30,19 +26,3 @@
   fail:
     msg: "Actual checksum {{ item_checksum.stat.checksum }} doesn't match expected checkum {{ item.checksum }}"
   when: item.checksum is defined and item.checksum != 'sha1:' ~ item_checksum.stat.checksum
-
-#- name: download {{ item.name }} if needed (checksum)
-#  become: yes
-#  become_user: "{{ item.owner }}"
-#  #command: wget --read-timeout=1200 {{ item.url }} -O {{ item.dest }}
-#  #ignore_errors: true
-#  get_url:
-#    timeout: 1200 # default value is too short for Pentaho Server download
-#    url: "{{ item.url }}"
-#    dest: "{{ item.dest }}"
-#    checksum: "{{ item.checksum }}"
-#  when: already_downloaded.stat.exists == False and item.checksum is defined
-#  register: item_downloaded
-#  until: not item_downloaded.failed
-#  retries: 10
-#  delay: 30

--- a/vagrant/provisioning/roles/confluent-platform-install/tasks/main.yml
+++ b/vagrant/provisioning/roles/confluent-platform-install/tasks/main.yml
@@ -35,7 +35,6 @@
 - name: Clean the yum caches
   become: yes
   command: yum clean all
-  ignore_errors: true
 
 - name: Install Confluent Platform
   become: yes

--- a/vagrant/provisioning/roles/foia-analytical-reports/tasks/main.yml
+++ b/vagrant/provisioning/roles/foia-analytical-reports/tasks/main.yml
@@ -5,7 +5,6 @@
 - name: Set reports version formatted
   set_fact:
     foia_analytical_reports_version_formatted: "{{ '-' ~ foia_analytical_reports_version if foia_analytical_reports_version != '' else '' }}"
-    
 
 - name: create install folder
   become: yes
@@ -214,7 +213,6 @@
   become_user: pentaho
   command: 
     cmd: 'wget --no-check-certificate -O {{ root_folder }}/install/pentaho/datasources-list.json --user={{ arkcase_admin_user }} --password "{{ arkcase_admin_password }}" https://{{ internal_host }}:2002/pentaho/plugin/data-access/api/datasource/jdbc/connection'
-  ignore_errors: true
   changed_when: false
 
 - name: read the list of data sources
@@ -236,7 +234,6 @@
 - name: create the ArkCase JDBC data source for analytical reports
   command: 
     cmd: 'wget --no-check-certificate --user={{ arkcase_admin_user }} --password "{{ arkcase_admin_password }}" --post-file {{ root_folder }}/install/pentaho/put_connection.json --header="Content-Type: application/json" https://{{ internal_host }}:2002/pentaho/plugin/data-access/api/connection/add'
-  ignore_errors: true
   register: create_datasource_rest_call
   when: not '"MariaDB Local"' in data_source_list.stdout
 
@@ -245,7 +242,6 @@
   become_user: pentaho
   command:
     cmd: 'curl -k -v -H "Content-Type: multipart/form-data" -X PUT -F uploadInput=@{{ root_folder }}/install/pentaho/foia-reports-dw{{ foia_analytical_reports_version_formatted }}/mondrian_schema/{{ foia_mondrian_schema_file }} -F overwrite=true -F xmlaEnabledFlag=false -F parameters="Datasource=MariaDB Local" -u {{ arkcase_admin_user }}:{{ arkcase_admin_password }} https://{{ internal_host }}:2002/pentaho/plugin/data-access/api/datasource/analysis/catalog/{{ foia_mondrian_schema_file | replace(".xml", "") }}'
-  ignore_errors: true
 
 #########################################################
 # Deploy the reports 

--- a/vagrant/provisioning/roles/foia/tasks/deploy_foia_report.yml
+++ b/vagrant/provisioning/roles/foia/tasks/deploy_foia_report.yml
@@ -12,13 +12,11 @@
   become: yes
   become_user: arkcase
   shell: unzip -u -o -j -d "{{ root_folder }}/install/arkcase" "{{ root_folder }}/install/arkcase/arkcase{{ arkcase_version_formatted }}.war" WEB-INF/lib/acm-foia-*.jar
-  ignore_errors: true
 
 - name: unzip report definition file "{{ r }}"
   become: yes
   become_user: arkcase
   shell: unzip -u -o -j -d "{{ root_folder }}/tmp/arkcase/" "{{ root_folder }}/install/arkcase/acm-foia-*.jar"  "reports/{{ r }}"
-  ignore_errors: true
 
 - name: copy the report definition file "{{ r }}", this will tell us if it changed
   become: yes

--- a/vagrant/provisioning/roles/pentaho-configuration/tasks/deploy_extension_report.yml
+++ b/vagrant/provisioning/roles/pentaho-configuration/tasks/deploy_extension_report.yml
@@ -16,7 +16,6 @@
   become: yes
   become_user: pentaho
   command: unzip -u -o -j -d {{ root_folder }}/install/pentaho/report-definitions/extension/{{ r.pentaho_path }} {{ root_folder }}/install/pentaho/{{ arkcase_extension_id }}{{ arkcase_extension_version_formatted }}.jar "{{ r.jar_path }}"
-  ignore_errors: true
   register: report_definition
   changed_when: "'inflated' in report_definition.stdout or 'inflating' in report_definition.stdout"
   

--- a/vagrant/provisioning/roles/pentaho-ee/tasks/main.yaml
+++ b/vagrant/provisioning/roles/pentaho-ee/tasks/main.yaml
@@ -38,7 +38,6 @@
   command: unzip -j -d "{{ root_folder }}/tmp/pentaho/{{ item }}" "{{ root_folder }}/install/pentaho/{{ item }}-{{ pentaho_major_version }}.{{ pentaho_minor_version }}-dist.zip"
   args:
     creates: "{{ root_folder }}/tmp/pentaho/{{ item }}/license.txt"
-  ignore_errors: true
   loop:
     - paz-plugin-ee
     - pdd-plugin-ee

--- a/vagrant/provisioning/roles/pentaho-pdi-client/tasks/main.yml
+++ b/vagrant/provisioning/roles/pentaho-pdi-client/tasks/main.yml
@@ -81,7 +81,6 @@
   command: unzip -j -d "{{ root_folder }}/tmp/pentaho-pdi/{{ item }}" "{{ root_folder }}/install/pentaho-pdi/{{ item }}-{{ pentaho_major_version }}.{{ pentaho_minor_version }}-dist.zip"
   args:
     creates: "{{ root_folder }}/tmp/pentaho-pdi/{{ item }}/license.txt"
-  ignore_errors: true
   loop:
     - pdi-ee-client
 

--- a/vagrant/provisioning/roles/privacy/tasks/deploy_privacy_report.yml
+++ b/vagrant/provisioning/roles/privacy/tasks/deploy_privacy_report.yml
@@ -12,13 +12,11 @@
   become: yes
   become_user: arkcase
   shell: unzip -u -o -j -d "{{ root_folder }}/install/arkcase" "{{ root_folder }}/install/arkcase/arkcase{{ arkcase_version_formatted }}.war" WEB-INF/lib/acm-privacy-*.jar
-  ignore_errors: true
 
 - name: unzip report definition file "{{ r }}"
   become: yes
   become_user: arkcase
   shell: unzip -u -o -j -d "{{ root_folder }}/tmp/arkcase/" "{{ root_folder }}/install/arkcase/acm-privacy-*.jar"  "reports/{{ r }}"
-  ignore_errors: true
 
 - name: copy the report definition file "{{ r }}", this will tell us if it changed
   become: yes

--- a/vagrant/provisioning/roles/snowbound-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/snowbound-app/tasks/main.yml
@@ -74,7 +74,6 @@
   command: unzip -o snowbound-integration-{{ snowbound_vendor_version }}{{ snowbound_arkcase_version_formatted }}.war WEB-INF/web.xml
   args:
     chdir: "{{ root_folder }}/install/snowbound"
-  ignore_errors: true
   when: snowbound_war is changed
 
 - name: fix the WEB-INF/web.xml file
@@ -102,7 +101,6 @@
   command: zip -r snowbound-integration-{{ snowbound_vendor_version }}{{ snowbound_arkcase_version_formatted }}.war WEB-INF
   args:
     chdir: "{{ root_folder }}/install/snowbound"
-  ignore_errors: true
   when: web_xml is changed
 
 - name: Update Snowbound war file

--- a/vagrant/provisioning/roles/virtualbox/tasks/get-guest-additions.yml
+++ b/vagrant/provisioning/roles/virtualbox/tasks/get-guest-additions.yml
@@ -4,7 +4,6 @@
     path: /usr/share/virtualbox
     state: directory
 
-
 - include_tasks: "{{ role_path }}/../common/tasks/download.yml"
   loop:
     - name: VirtualBox_Guest_Additions
@@ -22,7 +21,6 @@
     - name: mount guest additions
       become: yes
       shell: mount -t iso9660 -o loop /usr/share/virtualbox/VBoxGuestAdditions_{{ virtualbox_version }}.iso /mnt
-      ignore_errors: true
       when: mounted.stdout.find('VBoxGuestAdditions') == -1
     - name: build guest additions
       become: yes


### PR DESCRIPTION
Revert the recent ignore_errors additions (totally different semantics than 'warn: false').

In future, do not merge installer changes until I review them... I'll change the github merge rules if I have to.