### PR TITLE
Upgrading external roia portal to Java 11 and spring boot 2.6.7

### DIFF
--- a/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
+++ b/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
@@ -32,3 +32,6 @@ portal:
   security.authentication:
     header.parameter.name: foia-api-secret
     token:  "{{ portal_foiagov_token | default ('') }}"
+
+
+configServerUri: "{{ internal_host }}"

--- a/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
+++ b/vagrant/provisioning/roles/foia/templates/arkcase-portal-server-2020.16.yaml
@@ -34,4 +34,4 @@ portal:
     token:  "{{ portal_foiagov_token | default ('') }}"
 
 
-configServerUri: "{{ internal_host }}"
+configServerUri: "{{ internal_host }}/config"


### PR DESCRIPTION
External portal needed upgrading to Java 11 and spring boot to 2.6.7. 
Due to the change in spring-boot upgrade, additional line needed to be added for communication with config server, and replaced with the {{internal host}}/config

config:
  import: configserver:${configServerUri} 

configServerUri: http://localhost:9999