### PR TITLE
ACS-1453 cron job to start ArkCase if OpenJDK was updated

### DIFF
--- a/vagrant/provisioning/roles/start-arkcase/files/check-java-update-since-arkcase-start.sh
+++ b/vagrant/provisioning/roles/start-arkcase/files/check-java-update-since-arkcase-start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+ARKCASE_PID=$(systemctl status arkcase | grep "Main PID" | awk '{ print $3 }')
+if [[ "" == "$ARKCASE_PID" ]]; then
+  echo "ArkCase not running, exiting"
+  exit 1
+fi
+JAVA_HOME=$(xargs -0 -L1 -a /proc/"$ARKCASE_PID"/environ | grep JAVA_HOME | sed s.JAVA_HOME=..)
+JDK_TIMEZONE_UPDATE=$(stat "$JAVA_HOME"/jre/lib/tzdb.dat | grep Change | sed s/"Change: "// | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}')
+ARKCASE_START_TIME=$(systemctl status arkcase | grep Active | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}')
+if [[ "$JDK_TIMEZONE_UPDATE" > "$ARKCASE_START_TIME" ]]; then
+  echo "Restarting ArkCase"
+  systemctl restart arkcase
+fi
+

--- a/vagrant/provisioning/roles/start-arkcase/tasks/main.yml
+++ b/vagrant/provisioning/roles/start-arkcase/tasks/main.yml
@@ -58,3 +58,35 @@
     job: 'systemctl status arkcase || systemctl start arkcase'
     state: present
 
+- name: copy ArkCase restart check script
+  become: yes
+  become_method: sudo
+  copy:
+    backup: yes
+    content: |
+      #!/bin/bash
+      ARKCASE_PID=$(systemctl status arkcase | grep "Main PID" | awk '{ print $3 }')
+      if [[ "" == "$ARKCASE_PID" ]]; then
+        echo "ArkCase not running, exiting"
+        exit 1
+      fi
+      JAVA_HOME=$(xargs -0 -L1 -a /proc/"$ARKCASE_PID"/environ | grep JAVA_HOME | sed s.JAVA_HOME=..)
+      JDK_TIMEZONE_UPDATE=$(stat "$JAVA_HOME"/jre/lib/tzdb.dat | grep Change | sed s/"Change: "// | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}')
+      ARKCASE_START_TIME=$(systemctl status arkcase | grep Active | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}')
+      if [[ "$JDK_TIMEZONE_UPDATE" > "$ARKCASE_START_TIME" ]]; then
+        echo "Restarting ArkCase"
+        systemctl restart arkcase
+      fi
+    dest: "{{ root_folder }}/common/check-java-update-since-arkcase-start.sh"
+    mode: u=rwx,g=r,o=r
+
+- name: run CRON job hourly to see if ArkCase needs restarting due to JDK update
+  become: yes
+  become_method: sudo
+  cron:
+    name: "restart arkcase if OpenJDK was updated"
+    user: "root"
+    special_time: "hourly"
+    job: "/bin/sh {{ root_folder }}/common/check-java-update-since-arkcase-start.sh"
+    state: present
+

--- a/vagrant/provisioning/roles/start-arkcase/tasks/main.yml
+++ b/vagrant/provisioning/roles/start-arkcase/tasks/main.yml
@@ -58,25 +58,12 @@
     job: 'systemctl status arkcase || systemctl start arkcase'
     state: present
 
-- name: copy ArkCase restart check script
+- name: copy script to restart ArkCase if JDK was updated since ArkCase was started
   become: yes
   become_method: sudo
   copy:
     backup: yes
-    content: |
-      #!/bin/bash
-      ARKCASE_PID=$(systemctl status arkcase | grep "Main PID" | awk '{ print $3 }')
-      if [[ "" == "$ARKCASE_PID" ]]; then
-        echo "ArkCase not running, exiting"
-        exit 1
-      fi
-      JAVA_HOME=$(xargs -0 -L1 -a /proc/"$ARKCASE_PID"/environ | grep JAVA_HOME | sed s.JAVA_HOME=..)
-      JDK_TIMEZONE_UPDATE=$(stat "$JAVA_HOME"/jre/lib/tzdb.dat | grep Change | sed s/"Change: "// | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}')
-      ARKCASE_START_TIME=$(systemctl status arkcase | grep Active | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}')
-      if [[ "$JDK_TIMEZONE_UPDATE" > "$ARKCASE_START_TIME" ]]; then
-        echo "Restarting ArkCase"
-        systemctl restart arkcase
-      fi
+    src: check-java-update-since-arkcase-start.sh
     dest: "{{ root_folder }}/common/check-java-update-since-arkcase-start.sh"
     mode: u=rwx,g=r,o=r
 


### PR DESCRIPTION
This MR would have resolved the PRC outage earlier this week.  Although, it's still possible for a portal user to submit a request between the JDK update and when the cron next runs.