### PR TITLE
Initial commit for solr upgrade

### DIFF
--- a/vagrant/provisioning/arkcase-all.yml
+++ b/vagrant/provisioning/arkcase-all.yml
@@ -62,6 +62,8 @@
       tags: [alfresco-change-password]
     - role: remove-solr
       tags: [remove-solr]
+    - role: upgrade-solr
+      tags: [upgrade-solr]
     - role: zookeeper
       when: zookeeper_version is defined
       tags: [core, zookeeper]

--- a/vagrant/provisioning/arkcase-ce-facts.yml
+++ b/vagrant/provisioning/arkcase-ce-facts.yml
@@ -402,7 +402,7 @@ pentaho_ce_checksum: "sha1:3a27d54998f5001e0fd4cf843b727b0a127c7867"
 
 pentaho_server_url: "https://{{ external_host }}/arkcase/pentaho"
 
-solr_version: 8.8.2
+solr_version: 8.11.2
 solr_jmx_enabled: true
 # Cores are only needed for Solr before 8.8.2
 solr_cores:

--- a/vagrant/provisioning/arkcase-ce.yml
+++ b/vagrant/provisioning/arkcase-ce.yml
@@ -52,6 +52,8 @@
       tags: [core, zookeeper]
     - role: solr
       tags: [core, solr]
+    - role: upgrade-solr
+      tags: [upgrade-solr]
     - role: pentaho-setup
       tags: [core, pentaho, pentaho-setup]
     - role: pentaho-ce

--- a/vagrant/provisioning/arkcase-dev-facts.yml
+++ b/vagrant/provisioning/arkcase-dev-facts.yml
@@ -508,7 +508,7 @@ pentaho_ce_checksum: "sha1:3a27d54998f5001e0fd4cf843b727b0a127c7867"
 
 pentaho_server_url: "https://{{ external_host }}/arkcase/pentaho"
 
-solr_version: 8.8.2
+solr_version: 8.11.2
 solr_jmx_enabled: true
 # Cores are only needed for Solr before 8.8.2
 solr_cores:

--- a/vagrant/provisioning/arkcase-dev.yml
+++ b/vagrant/provisioning/arkcase-dev.yml
@@ -47,6 +47,8 @@
       tags: [core, zookeeper]
     - role: solr
       tags: [core, solr]
+    - role: upgrade-solr
+      tags: [upgrade-solr]
     - role: pentaho-setup
       tags: [core, pentaho, pentaho-setup]
     - role: pentaho-ce

--- a/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
@@ -1,65 +1,91 @@
-- name: stop arkcase
+- name: check for available disk space
   become: yes
-  systemd:
-    daemon_reload: true
-    name: arkcase
-    state: stopped
+  command: df -h /opt/
+  register: space_available
 
-- name: copy existing solr data to backup folder
+- name: check for solr data space
   become: yes
-  copy:
-    remote_src: yes
-    src: "{{ root_folder }}/data/solr/"
-    dest: "{{ root_folder }}/data/solr_backup/"
-    owner: solr
-    group: solr
+  stat:
+    path:  /opt/arkcase/data/solr
+  register: solr_data
 
-- name: delete solr cores from previous install
-  command: /opt/arkcase/app/solr/bin/solr delete -c {{ item }}
-  loop: "{{ solr_cores }}"
+- name: upgrade and backup solr if space is available under root_folder
+  block: 
+    - name: stop arkcase
+      become: yes
+      systemd:
+        name: arkcase
+        state: stopped
 
-- name: stop solr
+    - name: copy existing solr data to backup folder
+      become: yes
+      copy:
+        remote_src: yes
+        src: "{{ root_folder }}/data/solr/"
+        dest: "{{ root_folder }}/data/solr_backup/"
+        owner: solr
+        group: solr
+
+    - name: delete solr cores from previous install
+      command: /opt/arkcase/app/solr/bin/solr delete -c {{ item }}
+      loop: "{{ solr_cores }}"
+
+    - name: stop solr
+      become: yes
+      systemd:
+        name: solr
+        state: stopped
+
+    - name: Remove solr config files and folders
+      become: yes
+      file:
+        path: "{{ item }}"
+        state: absent
+        group: solr
+        owner: solr
+      loop:
+        - "{{ root_folder }}/data/solr"
+        - "{{ root_folder }}/app/solr"
+        - "{{ root_folder }}/install/solr"
+        - "/etc/systemd/system/solr.service"
+
+    - name: install solr
+      include_role: 
+        name: solr
+
+    - name: remove solr default data folder after upgrade
+      become: yes 
+      shell: rm -rf {{ root_folder }}/data/solr/*
+
+    - name: copy backup dir to new solr data dir
+      become: yes
+      copy:
+        remote_src: yes
+        src: "{{ root_folder }}/data/solr_backup/"
+        dest: "{{ root_folder }}/data/solr/"
+        owner: solr
+        group: solr
+
+    - name: restart service solr
+      become: yes
+      systemd:
+        daemon_reload: true
+        name: solr
+        state: restarted
+      
+    - name: wait for solr to start before start arkcase service
+      pause:
+        minutes: 1
+
+    - name: start service arkcase
+      become: yes
+      systemd:
+        name: arkcase
+        state: started
+  when: solr_data < space_available
+
+- name: output if there is not space available
   become: yes
-  systemd:
-    daemon_reload: true
-    name: solr
-    state: stopped
-
-- name: Remove solr config files and folders
-  become: yes
-  file:
-    path: "{{ item }}"
-    state: absent
-    group: solr
-    owner: solr
-  loop:
-    - "{{ root_folder }}/data/solr"
-    - "{{ root_folder }}/app/solr"
-    - "{{ root_folder }}/install/solr"
-    - "/etc/systemd/system/solr.service"
-
-- name: install solr
-  include_role: 
-    name: solr
-
-- name: remove solr default data folder after upgrade
-  become: yes 
-  shell: rm -rf {{ root_folder }}/data/solr/*
-
-- name: copy backup dir to new solr data dir
-  become: yes
-  copy:
-    remote_src: yes
-    src: "{{ root_folder }}/data/solr_backup/"
-    dest: "{{ root_folder }}/data/solr/"
-    owner: solr
-    group: solr
-
-- name: restart services arkcase and solr
-  become: yes
-  service:
-    name: "{{ item }}"
-    state: restarted
-  loop:
-    - solr
-    - arkcase
+  debug:
+    msg: "There is no space available under {{ root_folder }}"
+  when: solr_data > space_available

--- a/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
@@ -1,13 +1,17 @@
 - name: check for available disk space
   become: yes
-  command: df -h "{{ root_folder }}/"
+  shell: df -h "{{ root_folder }}/" | awk 'NR==2 { print $4 }'
   register: space_available
 
 - name: check for solr data space
   become: yes
-  stat:
-    path:  "{{ root_folder }}/data/solr"
+  shell: du -sh "{{ root_folder }}/data/solr" | awk '{ print $1 }'
   register: solr_data
+
+- name: format free space and solr data size output
+  set_fact:
+    space_available_formated: "{{ space_available.stdout | human_to_bytes | int }}"
+    solr_data_formated: "{{ solr_data.stdout | human_to_bytes | int }}"
 
 - name: upgrade and backup solr if space is available under root_folder
   block: 
@@ -90,10 +94,10 @@
         name: arkcase
         state: started
       when: _result.status == 200
-  when: solr_data < space_available
+  when: solr_data_formated < space_available_formated
 
 - name: output if there is not space available
   become: yes
   debug:
     msg: "There is no space available under {{ root_folder }}"
-  when: solr_data > space_available
+  when:  solr_data_formated > space_available_formated

--- a/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
@@ -1,0 +1,65 @@
+- name: stop arkcase
+  become: yes
+  systemd:
+    daemon_reload: true
+    name: arkcase
+    state: stopped
+
+- name: copy existing solr data to backup folder
+  become: yes
+  copy:
+    remote_src: yes
+    src: "{{ root_folder }}/data/solr/"
+    dest: "{{ root_folder }}/data/solr_backup/"
+    owner: solr
+    group: solr
+
+- name: delete solr cores from previous install
+  command: /opt/arkcase/app/solr/bin/solr delete -c {{ item }}
+  loop: "{{ solr_cores }}"
+
+- name: stop solr
+  become: yes
+  systemd:
+    daemon_reload: true
+    name: solr
+    state: stopped
+
+- name: Remove solr config files and folders
+  become: yes
+  file:
+    path: "{{ item }}"
+    state: absent
+    group: solr
+    owner: solr
+  loop:
+    - "{{ root_folder }}/data/solr"
+    - "{{ root_folder }}/app/solr"
+    - "{{ root_folder }}/install/solr"
+    - "/etc/systemd/system/solr.service"
+
+- name: install solr
+  include_role: 
+    name: solr
+
+- name: remove solr default data folder after upgrade
+  become: yes 
+  shell: rm -rf {{ root_folder }}/data/solr/*
+
+- name: copy backup dir to new solr data dir
+  become: yes
+  copy:
+    remote_src: yes
+    src: "{{ root_folder }}/data/solr_backup/"
+    dest: "{{ root_folder }}/data/solr/"
+    owner: solr
+    group: solr
+
+- name: restart services arkcase and solr
+  become: yes
+  service:
+    name: "{{ item }}"
+    state: restarted
+  loop:
+    - solr
+    - arkcase

--- a/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: check for available disk space
   become: yes
-  command: df -h /opt/
+  command: df -h "{{ root_folder }}/"
   register: space_available
 
 - name: check for solr data space
   become: yes
   stat:
-    path:  /opt/arkcase/data/solr
+    path:  "{{ root_folder }}/data/solr"
   register: solr_data
 
 - name: upgrade and backup solr if space is available under root_folder
@@ -27,7 +27,7 @@
         group: solr
 
     - name: delete solr cores from previous install
-      command: /opt/arkcase/app/solr/bin/solr delete -c {{ item }}
+      command: "{{ root_folder }}/app/solr/bin/solr delete -c {{ item }}"
       loop: "{{ solr_cores }}"
 
     - name: stop solr
@@ -73,15 +73,23 @@
         name: solr
         state: restarted
       
-    - name: wait for solr to start before start arkcase service
-      pause:
-        minutes: 1
+    - name: make sure solr is available
+      become: yes
+      uri:
+        validate_certs: false
+        url: https://{{ solr_host }}:8983/solr/
+        follow_redirects: none
+      register: _result
+      retries: 10
+      delay: 5
+      ignore_errors: yes
 
     - name: start service arkcase
       become: yes
       systemd:
         name: arkcase
         state: started
+      when: _result.status == 200
   when: solr_data < space_available
 
 - name: output if there is not space available


### PR DESCRIPTION
We can add delete of solr_backup at last, just for cleanup (i would leave the solr_backup because of not covered scenarios, just for backup and do a manual remove if everything is successful).
@david-oc-miller  any thoughts on this whole PR?
Also, i would want to test it on test core/foia envs, since they will be on k8s next week, so we can play with "real data" on this upgrade.