### PR TITLE
Need to revert to original

### DIFF
--- a/vagrant/provisioning/roles/solr/templates/solrconfig.xml
+++ b/vagrant/provisioning/roles/solr/templates/solrconfig.xml
@@ -101,7 +101,7 @@
        replication is in use, this should match the replication
        configuration.
     -->
-  <dataDir>${solr.data.home:}</dataDir>
+  <dataDir>${solr.data.dir:}</dataDir>
 
 
   <!-- The DirectoryFactory to use for indexes.


### PR DESCRIPTION
https://github.com/apache/lucene-solr/blob/branch_8_11/solr/server/solr/configsets/_default/conf/solrconfig.xml
This is according official repo on github. So, why did we need that change in the first place?