### PR TITLE
Refactor after run on foia test env

### DIFF
--- a/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
+++ b/vagrant/provisioning/roles/upgrade-solr/tasks/main.yml
@@ -13,6 +13,18 @@
     space_available_formated: "{{ space_available.stdout | human_to_bytes | int }}"
     solr_data_formated: "{{ solr_data.stdout | human_to_bytes | int * 2 }}"
 
+- name: check if we have some alias for our cores
+  become: yes
+  uri:
+    validate_certs: false
+    url: https://{{ solr_host }}:8983/solr/admin/collections?action=LISTALIASES
+    follow_redirects: none
+  register: core_alias
+
+- name: output info about aliases for core
+  debug:
+    msg: "{{ core_alias.json }}"
+
 - name: upgrade and backup solr if space is available under root_folder
   block: 
     - name: stop arkcase
@@ -23,7 +35,6 @@
 
     - name: copy existing solr data to backup folder
       become: yes
-      become_user: solr
       shell: mv {{ root_folder }}/data/solr/ {{ root_folder }}/data/solr_backup/
 
     - name: delete solr cores from previous install
@@ -46,23 +57,24 @@
       loop:
         - "{{ root_folder }}/data/solr"
         - "{{ root_folder }}/app/solr"
-        - "{{ root_folder }}/install/solr"
         - "/etc/systemd/system/solr.service"
 
     - name: install solr
       include_role: 
         name: solr
-
-    - name: remove solr default data folder after upgrade
-      become: yes 
-      shell: rm -rf {{ root_folder }}/data/solr/*
+        
+    - name: Remove default solr data
+      become: yes
+      file:
+        path: "{{ root_folder }}/data/solr"
+        state: absent
 
     - name: copy backup dir to new solr data dir
       become: yes
       copy:
         remote_src: yes
         src: "{{ root_folder }}/data/solr_backup/"
-        dest: "{{ root_folder }}/data/solr/"
+        dest: "{{ root_folder }}/data/solr"
         owner: solr
         group: solr
 
@@ -90,10 +102,10 @@
         name: arkcase
         state: started
       when: _result.status == 200
-  when: solr_data_formated < space_available_formated
+  when: solr_data_formated | int < space_available_formated | int
 
 - name: output if there is not space available
   become: yes
   debug:
     msg: "There is no space available under {{ root_folder }}"
-  when:  solr_data_formated > space_available_formated
+  when:  solr_data_formated | int > space_available_formated | int


### PR DESCRIPTION
Why this refactor?
I've run the code previous against core.test env. It run ok. 
On foia.test we have some differences, like aliases (this should be manually deleted or somehow otherwise managed) for cores. Other mods are regarding speed of the installment itself, different ansible versions (local vs Tower), and proper when checks.