### PR TITLE
ADS-1522: Executable permissions to pdfTron libraries

### DIFF
--- a/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-app/tasks/main.yml
@@ -1281,3 +1281,4 @@
     remote_src: yes
     src: "{{ root_folder }}/install/arkcase/pdftron_libraries.zip"
     dest: "{{ root_folder }}/data/arkcase-home/.arkcase/libraries"
+    mode: 0755


### PR DESCRIPTION
Added executable permissions to pdfTron libraries