### PR TITLE
Add PDFTron HTML2PDF Library Path Property

### DIFF
--- a/vagrant/provisioning/roles/arkcase-prerequisites/tasks/main.yml
+++ b/vagrant/provisioning/roles/arkcase-prerequisites/tasks/main.yml
@@ -214,6 +214,6 @@
     insertbefore: EOF
     marker: "# {mark} ANSIBLE MANAGED BLOCK - PdfTron"
     block: |
-      export JAVA_OPTS="$JAVA_OPTS -Djava.library.path={{ root_folder }}/data/arkcase-home/.arkcase/libraries:$LD_LIBRARY_PATH"
+      export JAVA_OPTS="$JAVA_OPTS -Djava.library.path={{ root_folder }}/data/arkcase-home/.arkcase/libraries:$LD_LIBRARY_PATH -Dpdftron.html2pdf.library.path={{ root_folder }}/data/arkcase-home/.arkcase/libraries"
   when: pdftron_viewer_license is defined
 


### PR DESCRIPTION
This pull request adds a new property named `pdftron.html2pdf.library.path` to the JAVA_OPTS for ArkCase.  This property is needed because the PDFTron HTML2PDF.setModulePath method requires that a single path be passed in as an argument, and it doesn't support lists of paths separated by colons.  So, it's necessary to add a dedicated property which only contains the path to the folder where the HTML2PDF library is located.