### PR TITLE
Bind httpd to all interfaces

### DIFF
--- a/vagrant/provisioning/roles/httpd/templates/httpd-ssl.conf
+++ b/vagrant/provisioning/roles/httpd/templates/httpd-ssl.conf
@@ -33,7 +33,7 @@ SSLRandomSeed connect file:/dev/urandom 512
 # When we also provide SSL we have to listen to the 
 # standard HTTP port (see above) and to the HTTPS port
 #
-Listen 127.0.0.1:488
+Listen 0.0.0.0:488
 
 ##
 ##  SSL Global Context


### PR DESCRIPTION
This change is needed we stopped adding "127.0.0.1 {{ internal_host }}" to /etc/hosts.  Since haproxy uses the host name as the route to httpd, this change to /etc/hosts means the host name no longer leads to localhost, which means haproxy can't talk to httpd anymore.  And I want haproxy to use the host name so it can verify TLS. Hence the need to bind httpd to all interfaces.