### PR TITLE
AKS-3303 - Increase Solr MaxFieldSize to account for larger file indexing messages

### DIFF
--- a/vagrant/provisioning/roles/solr/templates/solrconfig.xml
+++ b/vagrant/provisioning/roles/solr/templates/solrconfig.xml
@@ -1239,6 +1239,16 @@
     <processor class="solr.RunUpdateProcessorFactory"/>
   </updateRequestProcessorChain>
 
+  <updateRequestProcessorChain name="default">
+    <!-- Increase maximum field size due to sentence parsing issue from AKS-3301 -->
+    <processor class="solr.FieldValueMutator">
+      <str name="maxFieldLength">51200</str> <!-- Set to 50 KB, up from 32 KB default -->
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory"/>
+    <processor class="solr.DistributedUpdateProcessorFactory"/>
+    <processor class="solr.RunUpdateProcessorFactory"/>
+  </updateRequestProcessorChain>
+
   <!-- Deduplication
 
        An example dedup update processor that creates the "id" field


### PR DESCRIPTION
An example error from Preproduction:

> Document contains at least one immense term in field="content_sentence" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped.
...
original message: bytes can be at most 32766 in length; got 39940.

